### PR TITLE
fix(18): implement RootNodeDeleteIf

### DIFF
--- a/lib/janeway/interpreters/root_node_delete_if.rb
+++ b/lib/janeway/interpreters/root_node_delete_if.rb
@@ -1,33 +1,60 @@
 # frozen_string_literal: true
 
 require_relative 'root_node_interpreter'
+require_relative 'iteration_helper'
 
 module Janeway
   module Interpreters
-    # Interprets the root node for deletion
-    class RootNodeDeleter < RootNodeInterpreter
-      # Delete all values from the root node.
-      #
-      # TODO: unclear, for deletion is there a difference between queries '$' and '$.*'?
+    # Delete values from the root node for which the block returns a truthy value.
+    class RootNodeDeleteIf < RootNodeInterpreter
+      include IterationHelper
+
+      # @param node [AST::RootNode]
+      def initialize(node, &block)
+        super(node)
+        @block = block
+
+        # Make a proc that yields the correct number of values to a block
+        @yield_proc = make_yield_proc(&block)
+      end
+
+      # Delete values from the root container for which the block returns truthy.
       #
       # @param _input [Array, Hash] the results of processing so far
       # @param _parent [Array, Hash] parent of the input object
       # @param root [Array, Hash] the entire input
       # @param _path [Array<String>] elements of normalized path to the current input
       # @return [Array] deleted elements
-      def interpret(_input, _parent, root, _path)
+      def interpret(_input, _parent, root, _path = nil)
         case root
-        when Array
-          results = root.dup
-          root.clear
-          results
-        when Hash
-          results = root.values
-          root.clear
-          results
-        else
-          []
+        when Array then maybe_delete_array_values(root)
+        when Hash then maybe_delete_hash_values(root)
+        else []
         end
+      end
+
+      private
+
+      # @param input [Array]
+      def maybe_delete_array_values(input)
+        results = []
+        (input.size - 1).downto(0).each do |i|
+          next unless @yield_proc.call(input[i], input, ['$', i])
+
+          results << input.delete_at(i)
+        end
+        results.reverse
+      end
+
+      # @param input [Hash]
+      def maybe_delete_hash_values(input)
+        results = []
+        input.each do |key, value|
+          next unless @yield_proc.call(value, input, ['$', key])
+
+          results << input.delete(key)
+        end
+        results
       end
     end
   end

--- a/spec/lib/janeway/interpreter/root_node_delete_if_spec.rb
+++ b/spec/lib/janeway/interpreter/root_node_delete_if_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'janeway'
+
+module Janeway
+  module Interpreters
+    describe RootNodeDeleteIf do
+      it 'deletes array elements for which the block returns true' do
+        input = [1, 2, 3, 4]
+        Janeway.enum_for('$', input).delete_if(&:even?)
+        expect(input).to eq([1, 3])
+      end
+
+      it 'does not delete array elements when the block returns false' do
+        input = [1, 2, 3, 4]
+        Janeway.enum_for('$', input).delete_if { false }
+        expect(input).to eq([1, 2, 3, 4])
+      end
+
+      it 'deletes hash elements for which the block returns true' do
+        input = { 'a' => 1, 'b' => 2, 'c' => 3 }
+        Janeway.enum_for('$', input).delete_if { |value| value == 2 }
+        expect(input).to eq({ 'a' => 1, 'c' => 3 })
+      end
+
+      it 'does not delete hash elements when the block returns false' do
+        input = { 'a' => 1, 'b' => 2, 'c' => 3 }
+        Janeway.enum_for('$', input).delete_if { false }
+        expect(input).to eq({ 'a' => 1, 'b' => 2, 'c' => 3 })
+      end
+
+      it 'returns the values that were deleted from an array' do
+        input = [1, 2, 3, 4]
+        result = Janeway.enum_for('$', input).delete_if(&:even?)
+        expect(result).to eq([2, 4])
+      end
+
+      it 'returns the values that were deleted from a hash' do
+        input = { 'a' => 1, 'b' => 2, 'c' => 3 }
+        result = Janeway.enum_for('$', input).delete_if { |v| v.odd? }
+        expect(result).to eq([1, 3])
+      end
+    end
+  end
+end


### PR DESCRIPTION
The file lib/janeway/interpreters/root_node_delete_if.rb defined RootNodeDeleter (a copy-paste of root_node_deleter.rb) rather than RootNodeDeleteIf. TreeConstructor.ast_node_to_delete_if referenced RootNodeDeleteIf, so any delete_if invocation on the root query "$" raised NameError.

Rewrite the file to define RootNodeDeleteIf, mirroring the block-honoring pattern used in WildcardSelectorDeleteIf: gate each deletion on the IterationHelper yield_proc.