### PR TITLE
fix(19): honor block in negative-step array slice delete_if

### DIFF
--- a/lib/janeway/interpreters/array_slice_selector_delete_if.rb
+++ b/lib/janeway/interpreters/array_slice_selector_delete_if.rb
@@ -48,7 +48,11 @@ module Janeway
           results.reverse
         else
           indexes = upper.step(to: lower + 1, by: selector.step).to_a
-          indexes.each { |i| results << input.delete_at(i) }
+          indexes.each do |i|
+            next unless @yield_proc.call(input[i], input, path + [i])
+
+            results << input.delete_at(i)
+          end
           results
         end
       end

--- a/spec/lib/janeway/interpreter/array_slice_selector_delete_if_spec.rb
+++ b/spec/lib/janeway/interpreter/array_slice_selector_delete_if_spec.rb
@@ -47,6 +47,18 @@ module Janeway
         expect(input).to eq(('a'..'g').to_a)
       end
 
+      it 'does not delete values with negative step when block returns false' do
+        Janeway.enum_for('$[::-1]', input).delete_if { false }
+        expect(input).to eq(('a'..'g').to_a)
+      end
+
+      it 'selectively deletes values with negative step based on block result' do
+        input = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        result = Janeway.enum_for('$[::-1]', input).delete_if(&:even?)
+        expect(input).to eq([1, 3, 5, 7, 9])
+        expect(result).to eq([8, 6, 4, 2, 0])
+      end
+
       it 'can call instance methods on the matched values within the block' do
         input = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         Janeway.enum_for('$[::]', input).delete_if(&:even?)


### PR DESCRIPTION
The negative-step branch of ArraySliceSelectorDeleteIf#interpret called input.delete_at(i) unconditionally, ignoring @yield_proc. This silently deleted every element in a negative-step slice regardless of what the block returned.

Gate each deletion on @yield_proc.call, matching the positive-step branch.

Fixes #19 