### PR TITLE
fix(20): correct typo and assignment bug in Token#==

### DIFF
--- a/lib/janeway/token.rb
+++ b/lib/janeway/token.rb
@@ -31,7 +31,7 @@ module Janeway
       when Integer, String then @literal == other
       when Symbol then @type == other
       when Token
-        @type == other.type && @lexeme == other.lexem && @literal = other.literal
+        @type == other.type && @lexeme == other.lexeme && @literal == other.literal
       else
         raise ArgumentError, "don't know how to compare Token with #{other.inspect}"
       end

--- a/spec/lib/janeway/token_spec.rb
+++ b/spec/lib/janeway/token_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'janeway/token'
+require 'janeway/location'
+
+module Janeway
+  describe Token do
+    let(:location) { Location.new(0, 1) }
+
+    describe '#==' do
+      it 'returns true when comparing two tokens with the same type, lexeme, and literal' do
+        t1 = described_class.new(:number, '1', 1, location)
+        t2 = described_class.new(:number, '1', 1, location)
+        expect(t1 == t2).to be(true)
+      end
+
+      it 'returns false when comparing two tokens with different type' do
+        t1 = described_class.new(:number, '1', 1, location)
+        t2 = described_class.new(:string, '1', 1, location)
+        expect(t1 == t2).to be(false)
+      end
+
+      it 'returns false when comparing two tokens with different lexeme' do
+        t1 = described_class.new(:number, '1', 1, location)
+        t2 = described_class.new(:number, '2', 1, location)
+        expect(t1 == t2).to be(false)
+      end
+
+      it 'returns false when comparing two tokens with different literal' do
+        t1 = described_class.new(:number, '1', 1, location)
+        t2 = described_class.new(:number, '1', 2, location)
+        expect(t1 == t2).to be(false)
+      end
+
+      it 'does not mutate self when comparing two tokens with different literal' do
+        t1 = described_class.new(:number, '1', 1, location)
+        t2 = described_class.new(:number, '1', 2, location)
+        t1 == t2
+        expect(t1.literal).to eq(1)
+      end
+
+      it 'compares literal when other is an Integer' do
+        t = described_class.new(:number, '1', 1, location)
+        expect(t == 1).to be(true)
+        expect(t == 2).to be(false)
+      end
+
+      it 'compares literal when other is a String' do
+        t = described_class.new(:string, '"foo"', 'foo', location)
+        expect(t == 'foo').to be(true)
+        expect(t == 'bar').to be(false)
+      end
+
+      it 'compares type when other is a Symbol' do
+        t = described_class.new(:number, '1', 1, location)
+        expect(t == :number).to be(true)
+        expect(t == :string).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Token#== had two defects on one line:
  * `other.lexem` (missing 'e') — every Token-to-Token comparison raised NoMethodError.
  * `@literal = other.literal` used single `=` — even after the typo fix, the comparison would silently mutate self.

Change both to `==`. Add token_spec.rb covering same-value equality, each field's inequality path, non-mutation of self, and mixed-type comparison against Integer/String/Symbol.

Fixes #20 