### PR TITLE
fix(21): accept unknown keywords in ChildSegment#to_s

### DIFF
--- a/lib/janeway/ast/child_segment.rb
+++ b/lib/janeway/ast/child_segment.rb
@@ -32,7 +32,7 @@ module Janeway
         @value << selector
       end
 
-      def to_s(with_child: true)
+      def to_s(with_child: true, **)
         str = @value.map { |selector| selector.to_s(brackets: false, dot_prefix: false) }.join(', ')
         with_child ? "[#{str}]#{@next}" : "[#{str}]"
       end

--- a/spec/lib/janeway/query_spec.rb
+++ b/spec/lib/janeway/query_spec.rb
@@ -47,5 +47,11 @@ module Janeway
         end
       end
     end
+
+    describe '#to_s' do
+      it 'stringifies a descendant segment followed by a child segment' do
+        expect(Parser.parse('$..[1,2]').to_s).to eq('$..[1, 2]')
+      end
+    end
   end
 end


### PR DESCRIPTION
DescendantSegment#to_s calls @next.to_s(dot_prefix: false), but ChildSegment#to_s only declared with_child:. Any query where a descendant segment is followed by a child segment (e.g. "$..[1,2]") raised ArgumentError: unknown keyword: :dot_prefix from Query#to_s and, transitively, Query#== and Query#dup.

Add a `**` catch-all to ChildSegment#to_s, matching the pattern already used in ArraySliceSelector, FilterSelector, and IndexSelector.

Fixes: #21 