### PR TITLE
fix(22): emit operator character in UnaryOperator#to_s

### DIFF
--- a/lib/janeway/ast/unary_operator.rb
+++ b/lib/janeway/ast/unary_operator.rb
@@ -13,13 +13,23 @@ module Janeway
       end
 
       def to_s
-        "#{@operator} #{operand}"
+        "#{operator_to_s}#{operand}"
       end
 
       # @param level [Integer]
       # @return [Array]
       def tree(level)
-        indented(level, "#{operator}#{operand}")
+        indented(level, "#{operator_to_s}#{operand}")
+      end
+
+      private
+
+      def operator_to_s
+        case @name
+        when :not then '!'
+        else
+          raise "unknown unary operator #{@name}"
+        end
       end
     end
   end

--- a/spec/lib/janeway/query_spec.rb
+++ b/spec/lib/janeway/query_spec.rb
@@ -52,6 +52,15 @@ module Janeway
       it 'stringifies a descendant segment followed by a child segment' do
         expect(Parser.parse('$..[1,2]').to_s).to eq('$..[1, 2]')
       end
+
+      it 'preserves the logical-not operator when stringifying' do
+        expect(Parser.parse('$[?!@.x]').to_s).to include('!')
+      end
+
+      it 'round-trips a logical-not filter through parse -> to_s -> parse' do
+        original = Parser.parse('$[?!@.x]')
+        expect(Parser.parse(original.to_s).to_s).to eq(original.to_s)
+      end
     end
   end
 end


### PR DESCRIPTION
UnaryOperator#to_s interpolated @operator (which never existed — the ivar is @name), so the "!" character was silently dropped from any stringified filter that used it. Query#dup reparses to_s, so any dup'd query containing "!" changed semantics.

UnaryOperator#tree had a related bug: `operator` (bare method call) raised NoMethodError; tree just never happened to descend into unary operators today, so it was latent.

Add an operator_to_s helper mirroring BinaryOperator's pattern.

Fixes #22 