### PR TITLE
fix: guard tree() against nil @next in root, wildcard, current-node

### DIFF
--- a/lib/janeway/ast/current_node.rb
+++ b/lib/janeway/ast/current_node.rb
@@ -63,7 +63,7 @@ module Janeway
       # @param level [Integer]
       # @return [Array]
       def tree(level)
-        [indented(level, '@'), @next.tree(indent + 1)]
+        [indented(level, '@'), @next&.tree(level + 1)]
       end
     end
   end

--- a/lib/janeway/ast/root_node.rb
+++ b/lib/janeway/ast/root_node.rb
@@ -42,7 +42,7 @@ module Janeway
       # @param level [Integer]
       # @return [Array]
       def tree(level = 0)
-        [indented(level, '$'), @next.tree(level + 1)]
+        [indented(level, '$'), @next&.tree(level + 1)]
       end
     end
   end

--- a/lib/janeway/ast/wildcard_selector.rb
+++ b/lib/janeway/ast/wildcard_selector.rb
@@ -36,7 +36,7 @@ module Janeway
       # @param level [Integer]
       # @return [Array]
       def tree(level)
-        [indented(level, '*'), @next.tree(level + 1)]
+        [indented(level, '*'), @next&.tree(level + 1)]
       end
     end
   end

--- a/spec/lib/janeway/query_spec.rb
+++ b/spec/lib/janeway/query_spec.rb
@@ -48,6 +48,16 @@ module Janeway
       end
     end
 
+    describe '#tree' do
+      it 'does not raise for a bare root query' do
+        expect { Parser.parse('$').tree }.not_to raise_error
+      end
+
+      it 'does not raise for a wildcard selector as the terminal segment' do
+        expect { Parser.parse('$.a[*]').tree }.not_to raise_error
+      end
+    end
+
     describe '#to_s' do
       it 'stringifies a descendant segment followed by a child segment' do
         expect(Parser.parse('$..[1,2]').to_s).to eq('$..[1, 2]')


### PR DESCRIPTION
RootNode#tree, WildcardSelector#tree, and CurrentNode#tree all called @next.tree(...) unconditionally, so Query#tree crashed with NoMethodError on legal terminal queries like "$" and "$.a[*]". CurrentNode#tree additionally called `indent + 1` where `indent` resolves to the (2-arg) `indented` method — a latent bug that would raise if reached.

Use safe navigation (`@next&.tree(level + 1)`), matching the pattern already used in ChildSegment, DescendantSegment, and NameSelector.

Fixes #23 