### PR TITLE
fix(25): preserve quotes around name selectors inside a union

### DIFF
--- a/lib/janeway/ast/child_segment.rb
+++ b/lib/janeway/ast/child_segment.rb
@@ -33,7 +33,7 @@ module Janeway
       end
 
       def to_s(with_child: true, **)
-        str = @value.map { |selector| selector.to_s(brackets: false, dot_prefix: false) }.join(', ')
+        str = @value.map { |selector| selector.to_s(brackets: false, dot_prefix: false, bracketed: true) }.join(', ')
         with_child ? "[#{str}]#{@next}" : "[#{str}]"
       end
 

--- a/lib/janeway/ast/name_selector.rb
+++ b/lib/janeway/ast/name_selector.rb
@@ -19,14 +19,17 @@ module Janeway
 
       # @param brackets [Boolean] request for bracket syntax
       # @param dot_prefix [Boolean] include . prefix, if shorthand notation is used
-      def to_s(brackets: false, dot_prefix: true)
+      # @param bracketed [Boolean] caller already provided brackets (e.g. within a union);
+      #   emit the quoted name only, without adding brackets
+      def to_s(brackets: false, dot_prefix: true, bracketed: false)
         # Add quotes and surrounding brackets if the name includes chars that require quoting.
         # These chars are not allowed in dotted notation, only bracket notation.
         special_chars = [' ', '.']
         brackets ||= special_chars.any? { |char| @value.include?(char) }
-        if brackets
-          name_str = quote(@value)
-          "[#{name_str}]#{@next}"
+        if bracketed
+          "#{quote(@value)}#{@next}"
+        elsif brackets
+          "[#{quote(@value)}]#{@next}"
         elsif dot_prefix
           ".#{@value}#{@next}"
         else # omit dot prefix after a descendant segment

--- a/lib/janeway/ast/wildcard_selector.rb
+++ b/lib/janeway/ast/wildcard_selector.rb
@@ -23,7 +23,7 @@ module Janeway
       end
 
       # @return [String]
-      def to_s(brackets: false, dot_prefix: true)
+      def to_s(brackets: false, dot_prefix: true, **)
         if brackets
           "[*]#{@next&.to_s(brackets: true)}"
         elsif dot_prefix

--- a/spec/lib/janeway/query_spec.rb
+++ b/spec/lib/janeway/query_spec.rb
@@ -71,6 +71,10 @@ module Janeway
         original = Parser.parse('$[?!@.x]')
         expect(Parser.parse(original.to_s).to_s).to eq(original.to_s)
       end
+
+      it 'preserves quotes around name selectors in a union' do
+        expect(Parser.parse("$['a','b']").to_s).to eq("$['a', 'b']")
+      end
     end
   end
 end


### PR DESCRIPTION
ChildSegment#to_s called each element with (brackets: false, dot_prefix: false). For a NameSelector, that mode emitted the bare name — correct after a descendant segment ("..a") but wrong inside a union: "$['a','b']" round-tripped to "$[a, b]", which then failed to re-parse (lexer rejects unquoted names inside brackets).

Add a `bracketed:` kwarg to NameSelector#to_s. When true, emit the quoted name without adding its own brackets (the parent supplies them). ChildSegment sets bracketed: true when rendering union members. Also add a `**` catch-all to WildcardSelector#to_s so the new keyword passes through harmlessly for wildcard unions.

Fixes #25 