### PR TITLE
perf: clone AST directly in Query#dup instead of re-parsing

### DIFF
--- a/lib/janeway/query.rb
+++ b/lib/janeway/query.rb
@@ -76,10 +76,19 @@ module Janeway
       result.flatten.join("\n")
     end
 
-    # Deep copy the query
+    # Deep copy the query.
+    #
+    # Only the top-level linked list of segments/selectors is cloned — that is
+    # the only part `pop` mutates. Nested contents (filter expressions,
+    # function parameters, child-segment members) are shared with the original,
+    # which is safe because the interpreter never mutates the AST.
+    #
     # @return [Query]
     def dup
-      Parser.parse(to_s)
+      cloned = node_list.map(&:dup)
+      cloned.each_cons(2) { |a, b| a.next = b }
+      cloned.last.next = nil
+      Query.new(cloned.first, @jsonpath)
     end
 
     # Delete the last element from the chain of selectors.


### PR DESCRIPTION
Query#dup previously called Parser.parse(to_s), so every dup lexed and parsed the entire query string from scratch. Enumerator#find_parent (called from #insert) dupes the query on every call, making bulk-insert workloads pay full parse cost per row.

Only the top-level segment/selector chain is cloned — the only part that #pop mutates. Nested contents (filter expressions, function parameters, child-segment members) are shared with the original, which is safe because the interpreter treats the AST as immutable (see the Query class docstring).

Benchmark on 20k inserts against "$.a.b.c.d.e.new_key":
  before: 121 us/op
  after:  77 us/op   (1.57x)

fixes #36 