### PR TITLE
perf: replace O(n) Array#include? / Hash#key with O(1) Hash lookups

### DIFF
--- a/lib/janeway/lexer.rb
+++ b/lib/janeway/lexer.rb
@@ -38,9 +38,23 @@ module Janeway
     TWO_CHAR_LEX_FIRST = TWO_CHAR_LEX.map { |lexeme| lexeme[0] }.freeze
     ONE_OR_TWO_CHAR_LEX = ONE_CHAR_LEX & TWO_CHAR_LEX.map { |str| str[0] }.freeze
 
+    # O(1)-lookup companions to the arrays above. Hash#include? and the reverse
+    # lookup avoid the linear scan that .include? / .key would do per token.
+    LEXEME_TO_TYPE = OPERATORS.invert.freeze
+    ONE_CHAR_LEX_SET = ONE_CHAR_LEX.each_with_object({}) { |c, h| h[c] = true }.freeze
+    TWO_CHAR_LEX_SET = TWO_CHAR_LEX.each_with_object({}) { |c, h| h[c] = true }.freeze
+    TWO_CHAR_LEX_FIRST_SET = TWO_CHAR_LEX_FIRST.each_with_object({}) { |c, h| h[c] = true }.freeze
+    ONE_OR_TWO_CHAR_LEX_SET = ONE_OR_TWO_CHAR_LEX.each_with_object({}) { |c, h| h[c] = true }.freeze
+
     WHITESPACE = " \t\n\r"
     KEYWORD = %w[true false null].freeze
+    KEYWORD_SET = KEYWORD.each_with_object({}) { |k, h| h[k] = true }.freeze
     FUNCTIONS = %w[length count match search value].freeze
+    FUNCTIONS_SET = FUNCTIONS.each_with_object({}) { |k, h| h[k] = true }.freeze
+
+    # Hoisted from lex_delimited_string. Given a delimiter, the value is the "other" delimiter.
+    OTHER_DELIMITER = { "'" => '"', '"' => "'" }.freeze
+    QUOTE_LEX_SET = { "'" => true, '"' => true }.freeze
 
     # faster to check membership in a string than an array of char (benchmarked ruby 3.1.2)
     ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -89,13 +103,13 @@ module Janeway
       return if WHITESPACE.include?(c)
 
       token =
-        if ONE_OR_TWO_CHAR_LEX.include?(c)
+        if ONE_OR_TWO_CHAR_LEX_SET.include?(c)
           token_from_one_or_two_char_lex(c)
-        elsif ONE_CHAR_LEX.include?(c)
+        elsif ONE_CHAR_LEX_SET.include?(c)
           token_from_one_char_lex(c)
-        elsif TWO_CHAR_LEX_FIRST.include?(c)
+        elsif TWO_CHAR_LEX_FIRST_SET.include?(c)
           token_from_two_char_lex(c)
-        elsif %w[" '].include?(c)
+        elsif QUOTE_LEX_SET.include?(c)
           lex_delimited_string(c)
         elsif digit?(c)
           lex_number
@@ -127,20 +141,20 @@ module Janeway
         raise err("Operator #{lexeme.inspect} must not be followed by whitespace")
       end
 
-      Token.new(OPERATORS.key(lexeme), lexeme, nil, current_location)
+      Token.new(LEXEME_TO_TYPE[lexeme], lexeme, nil, current_location)
     end
 
     # Consumes an operator that could be either 1 or 2 chars in length
     # @return [Token]
     def token_from_one_or_two_char_lex(lexeme)
-      next_two_chars = [lexeme, lookahead].join
-      if TWO_CHAR_LEX.include?(next_two_chars)
+      next_two_chars = lexeme + lookahead
+      if TWO_CHAR_LEX_SET.include?(next_two_chars)
         consume
         if next_two_chars == '..' && WHITESPACE.include?(lookahead)
           raise err("Operator #{next_two_chars.inspect} must not be followed by whitespace")
         end
 
-        Token.new(OPERATORS.key(next_two_chars), next_two_chars, nil, current_location)
+        Token.new(LEXEME_TO_TYPE[next_two_chars], next_two_chars, nil, current_location)
       else
         token_from_one_char_lex(lexeme)
       end
@@ -149,11 +163,11 @@ module Janeway
     # Consumes a 2 char operator
     # @return [Token]
     def token_from_two_char_lex(lexeme)
-      next_two_chars = [lexeme, lookahead].join
-      raise err("Unknown operator \"#{lexeme}\"") unless TWO_CHAR_LEX.include?(next_two_chars)
+      next_two_chars = lexeme + lookahead
+      raise err("Unknown operator \"#{lexeme}\"") unless TWO_CHAR_LEX_SET.include?(next_two_chars)
 
       consume
-      Token.new(OPERATORS.key(next_two_chars), next_two_chars, nil, current_location)
+      Token.new(LEXEME_TO_TYPE[next_two_chars], next_two_chars, nil, current_location)
     end
 
     def consume
@@ -169,9 +183,8 @@ module Janeway
     # @param delimiter [String] eg. ' or "
     # @return [Token] string token
     def lex_delimited_string(delimiter)
-      allowed_delimiters = %w[' "]
       # the "other" delimiter char, which is not currently being treated as a delimiter
-      non_delimiter = allowed_delimiters.reject { |char| char == delimiter }.first
+      non_delimiter = OTHER_DELIMITER[delimiter]
 
       literal_chars = []
       while lookahead != delimiter && source_uncompleted?
@@ -190,7 +203,7 @@ module Janeway
             end
           elsif unescaped?(next_char)
             consume
-          elsif allowed_delimiters.include?(next_char) && next_char != delimiter
+          elsif QUOTE_LEX_SET.include?(next_char) && next_char != delimiter
             consume
           else
             raise err("invalid character #{next_char.inspect}")
@@ -383,9 +396,9 @@ module Janeway
 
       identifier = source[lexeme_start_p..(next_p - 1)]
       type =
-        if KEYWORD.include?(identifier) && !ignore_keywords
+        if KEYWORD_SET.include?(identifier) && !ignore_keywords
           identifier.to_sym
-        elsif FUNCTIONS.include?(identifier) && !ignore_keywords
+        elsif FUNCTIONS_SET.include?(identifier) && !ignore_keywords
           :function
         else
           :identifier
@@ -486,9 +499,9 @@ module Janeway
       consume while name_char?(lookahead)
       identifier = source[lexeme_start_p..(next_p - 1)]
       type =
-        if KEYWORD.include?(identifier) && !ignore_keywords
+        if KEYWORD_SET.include?(identifier) && !ignore_keywords
           identifier.to_sym
-        elsif FUNCTIONS.include?(identifier) && !ignore_keywords
+        elsif FUNCTIONS_SET.include?(identifier) && !ignore_keywords
           :function
         else
           :identifier

--- a/lib/janeway/parser.rb
+++ b/lib/janeway/parser.rb
@@ -16,6 +16,19 @@ module Janeway
     UNARY_OPERATORS = %w[! -].freeze
     BINARY_OPERATORS = %w[== != > < >= <= ,].freeze
     LOGICAL_OPERATORS = %w[&& ||].freeze
+
+    # O(1)-lookup Hash companions to the arrays above, plus the union used by
+    # determine_infix_function. Building these inline in the hot path
+    # allocated a fresh Array per token; hoisting eliminates it.
+    UNARY_OPERATOR_SET = UNARY_OPERATORS.each_with_object({}) { |op, h| h[op] = true }.freeze
+    BINARY_OPERATOR_SET = BINARY_OPERATORS.each_with_object({}) { |op, h| h[op] = true }.freeze
+    INFIX_OPERATOR_SET =
+      (BINARY_OPERATORS + LOGICAL_OPERATORS).each_with_object({}) { |op, h| h[op] = true }.freeze
+    PARSE_METHOD_TYPES =
+      %I[identifier number string true false nil function if while root current_node]
+      .each_with_object({}) { |t, h| h[t] = true }.freeze
+    TERMINATOR_TYPES = %I[child_end union eof].each_with_object({}) { |t, h| h[t] = true }.freeze
+    NEWLINE_OR_EOF_TYPES = { :"\n" => true, eof: true }.freeze
     LOWEST_PRECEDENCE = 0
     OPERATOR_PRECEDENCE = {
       ',' => 0,
@@ -135,14 +148,13 @@ module Janeway
     end
 
     def determine_parsing_function
-      parse_methods = %I[identifier number string true false nil function if while root current_node]
-      if parse_methods.include?(current.type)
+      if PARSE_METHOD_TYPES.include?(current.type)
         :"parse_#{current.type}"
       elsif current.type == :group_start # (
         :parse_grouped_expr
-      elsif %I[\n eof].include?(current.type)
+      elsif NEWLINE_OR_EOF_TYPES.include?(current.type)
         :parse_terminator
-      elsif UNARY_OPERATORS.include?(current.lexeme)
+      elsif UNARY_OPERATOR_SET.include?(current.lexeme)
         :parse_unary_operator
       elsif current.type == :child_start # [
         :parse_child_segment
@@ -161,7 +173,7 @@ module Janeway
 
     # @return [nil, Symbol]
     def determine_infix_function(token = current)
-      return unless (BINARY_OPERATORS + LOGICAL_OPERATORS).include?(token.lexeme)
+      return unless INFIX_OPERATOR_SET.include?(token.lexeme)
 
       :parse_binary_operator
     end
@@ -481,11 +493,10 @@ module Janeway
     # Feed tokens to the FilterSelector until hitting a terminator
     def parse_filter_selector
       selector = AST::FilterSelector.new
-      terminator_types = %I[child_end union eof]
-      while next_token && !terminator_types.include?(next_token.type)
+      while next_token && !TERMINATOR_TYPES.include?(next_token.type)
         consume
         node =
-          if BINARY_OPERATORS.include?(current.lexeme)
+          if BINARY_OPERATOR_SET.include?(current.lexeme)
             parse_binary_operator(selector.value)
           else
             parse_expr_recursively


### PR DESCRIPTION
Both the lexer and the parser used Array#include? in per-character or per-token hot paths, and the lexer used OPERATORS.key(lexeme) — a reverse hash scan — to look up token types. The collections are small so this was never catastrophic, but scanning them for every input character adds up.

Add O(1) Hash-backed companions to the existing constants and switch the hot paths to them:

  Lexer:
    ONE_CHAR_LEX_SET, TWO_CHAR_LEX_SET, TWO_CHAR_LEX_FIRST_SET,
    ONE_OR_TWO_CHAR_LEX_SET, KEYWORD_SET, FUNCTIONS_SET, QUOTE_LEX_SET.
    LEXEME_TO_TYPE (OPERATORS.invert) replaces OPERATORS.key(...).

  Parser:
    UNARY_OPERATOR_SET, BINARY_OPERATOR_SET, INFIX_OPERATOR_SET
    (pre-unioned BINARY + LOGICAL), PARSE_METHOD_TYPES,
    TERMINATOR_TYPES, NEWLINE_OR_EOF_TYPES.

Also hoist a couple of per-call Array literals — `allowed_delimiters` in lex_delimited_string, `parse_methods` in determine_parsing_function, `terminator_types` in parse_filter_selector — to frozen module constants (they were allocated fresh on every invocation).

Fixes #38 

Benchmark on repeated parses across 6 representative queries:
  before: 68.7 us/parse
  after:  62.3 us/parse  (1.10x)