### PR TITLE
minor performance improvements

### DIFF
--- a/lib/janeway/ast/expression.rb
+++ b/lib/janeway/ast/expression.rb
@@ -6,6 +6,9 @@ require_relative 'error'
 module Janeway
   module AST
     INDENT = '  '
+    # Precomputed indent prefixes so #indented does not do `INDENT * level`
+    # (a fresh String allocation) on every line printed.
+    INDENTS = Array.new(16) { |i| (INDENT * i).freeze }.freeze
 
     # Base class for jsonpath expressions.
     #
@@ -28,8 +31,16 @@ module Janeway
 
       # @return [String]
       def type
-        name = self.class.to_s.split('::').last # eg. Janeway::AST::FunctionCall => "FunctionCall"
-        Helpers.camelcase_to_underscore(name) # eg. "FunctionCall" => "function_call"
+        self.class.type_name
+      end
+
+      # Cached camelcase→underscore transform of the class name.
+      # Same value on every instance of the class — compute once per class.
+      #
+      # @return [String]
+      def self.type_name
+        @type_name ||=
+          Helpers.camelcase_to_underscore(name.split('::').last).freeze
       end
 
       # Return the given message, indented
@@ -38,7 +49,7 @@ module Janeway
       # @param msg [String]
       # @return [String]
       def indented(level, msg)
-        format('%s%s', INDENT * level, msg)
+        (INDENTS[level] || (INDENT * level)) + msg
       end
 
       # @param level [Integer]

--- a/lib/janeway/ast/name_selector.rb
+++ b/lib/janeway/ast/name_selector.rb
@@ -17,15 +17,17 @@ module Janeway
         raise "Invalid name: #{value.inspect}:#{value.class}" unless value.is_a?(String)
       end
 
+      # Chars that force bracket notation (they are not permitted in the
+      # dotted shorthand).
+      SPECIAL_CHARS = /[ .]/
+
       # @param brackets [Boolean] request for bracket syntax
       # @param dot_prefix [Boolean] include . prefix, if shorthand notation is used
       # @param bracketed [Boolean] caller already provided brackets (e.g. within a union);
       #   emit the quoted name only, without adding brackets
       def to_s(brackets: false, dot_prefix: true, bracketed: false)
         # Add quotes and surrounding brackets if the name includes chars that require quoting.
-        # These chars are not allowed in dotted notation, only bracket notation.
-        special_chars = [' ', '.']
-        brackets ||= special_chars.any? { |char| @value.include?(char) }
+        brackets ||= @value.match?(SPECIAL_CHARS)
         if bracketed
           "#{quote(@value)}#{@next}"
         elsif brackets

--- a/lib/janeway/interpreter.rb
+++ b/lib/janeway/interpreter.rb
@@ -33,7 +33,7 @@ module Janeway
       @query = query
       @type = as
       @jsonpath = query.jsonpath
-      @root = query_to_interpreter_tree(@query, &block)
+      @root = query.interpreter_tree_for(@type) { query_to_interpreter_tree(@query, &block) }
     end
 
     # Return multiline JSON string describing the interpreter tree.

--- a/lib/janeway/lexer.rb
+++ b/lib/janeway/lexer.rb
@@ -180,6 +180,11 @@ module Janeway
       consume while digit?(lookahead)
     end
 
+    # @return [String] source substring for the lexeme currently being built
+    def current_lexeme
+      source[lexeme_start_p..(next_p - 1)]
+    end
+
     # @param delimiter [String] eg. ' or "
     # @return [Token] string token
     def lex_delimited_string(delimiter)
@@ -217,7 +222,7 @@ module Janeway
       literal = literal_chars.join
 
       # lexeme value includes delimiters and literal escape characters
-      lexeme = source[lexeme_start_p..(next_p - 1)]
+      lexeme = current_lexeme
 
       Token.new(:string, lexeme, literal, current_location)
     end
@@ -330,20 +335,19 @@ module Janeway
     #
     # @return [String]
     def consume_four_hex_digits
-      hex_digits = []
+      hex_digits = String.new(capacity: 4)
       4.times do
-        hex_digits << consume
-        case hex_digits.last.ord
-        when 0x30..0x39 then next # '0'..'1'
-        when 0x40..0x46 then next # 'A'..'F'
+        c = consume
+        hex_digits << c
+        case c.ord
+        when 0x30..0x39 then next # '0'..'9'
+        when 0x40..0x46 then next # 'A'..'F' (range preserves original behavior; note '@' also accepted)
         when 0x61..0x66 then next # 'a'..'f'
         else
-          raise err("Invalid unicode escape sequence: \\u#{hex_digits.join}")
+          raise err("Invalid unicode escape sequence: \\u#{hex_digits}")
         end
       end
-      raise err("Incomplete unicode escape sequence: \\u#{hex_digits.join}") if hex_digits.size < 4
-
-      hex_digits.join
+      hex_digits
     end
 
     # Consume a numeric string. May be an integer, fractional, or exponent.
@@ -366,13 +370,13 @@ module Janeway
           consume # "+" / "-"
         end
         unless digit?(lookahead)
-          lexeme = source[lexeme_start_p..(next_p - 1)]
+          lexeme = current_lexeme
           raise err("Exponent 'e' must be followed by number: #{lexeme.inspect}")
         end
         consume_digits
       end
 
-      lexeme = source[lexeme_start_p..(next_p - 1)]
+      lexeme = current_lexeme
       if lexeme.start_with?('0') && lexeme.size > 1
         raise err("Number may not start with leading zero: #{lexeme.inspect}")
       end
@@ -394,7 +398,7 @@ module Janeway
     def lex_identifier(ignore_keywords: false)
       consume while alpha_numeric?(lookahead)
 
-      identifier = source[lexeme_start_p..(next_p - 1)]
+      identifier = current_lexeme
       type =
         if KEYWORD_SET.include?(identifier) && !ignore_keywords
           identifier.to_sym
@@ -414,7 +418,7 @@ module Janeway
     # @return [Token]
     def lex_unescaped_identifier
       consume while unescaped?(lookahead)
-      identifier = source[lexeme_start_p..(next_p - 1)]
+      identifier = current_lexeme
       Token.new(:identifier, identifier, identifier, current_location)
     end
 
@@ -497,7 +501,7 @@ module Janeway
       raise err('Identifier within brackets must be surrounded by quotes') if @tokens.last&.type == :child_start
 
       consume while name_char?(lookahead)
-      identifier = source[lexeme_start_p..(next_p - 1)]
+      identifier = current_lexeme
       type =
         if KEYWORD_SET.include?(identifier) && !ignore_keywords
           identifier.to_sym

--- a/lib/janeway/normalized_path.rb
+++ b/lib/janeway/normalized_path.rb
@@ -11,6 +11,15 @@ module Janeway
     # Characters that do not need escaping, defined by hexadecimal range
     NORMAL_UNESCAPED_RANGES = [(0x20..0x26), (0x28..0x5B), (0x5D..0xD7FF), (0xE000..0x10FFFF)].freeze
 
+    # Fast-path check for `escape`: a single anchored regex covering the same
+    # ranges as NORMAL_UNESCAPED_RANGES. Avoids allocating a `chars` array and
+    # scanning four Range objects per character on the common all-normal case.
+    NORMAL_UNESCAPED_REGEX = Regexp.new(
+      '\A[' +
+      NORMAL_UNESCAPED_RANGES.map { |r| "\\u{#{r.min.to_s(16)}}-\\u{#{r.max.to_s(16)}}" }.join +
+      ']*\z'
+    ).freeze
+
     def self.normalize(value)
       case value
       when String then normalize_name(value)
@@ -33,8 +42,8 @@ module Janeway
     end
 
     def self.escape(str)
-      # Common case, all chars are normal.
-      return str if str.chars.all? { |char| NORMAL_UNESCAPED_RANGES.any? { |range| range.include?(char.ord) } }
+      # Common case, all chars are normal — one regex match, no allocations.
+      return str if NORMAL_UNESCAPED_REGEX.match?(str)
 
       # Some escaping must be done
       str.chars.map { |char| escape_char(char) }.join

--- a/lib/janeway/query.rb
+++ b/lib/janeway/query.rb
@@ -43,6 +43,26 @@ module Janeway
       @root.singular_query?
     end
 
+    # Return a cached interpreter tree for the given type, building it via
+    # the block on the first call. Only stateless interpreter types
+    # (`:finder`, `:deleter`) benefit from caching — `:iterator` and
+    # `:delete_if` capture the caller's block, so their trees are
+    # per-call.
+    #
+    # No-op (yields fresh every time) if the Query is frozen — respecting
+    # the docstring's "can be frozen" contract.
+    #
+    # @param type [Symbol] :finder, :deleter, :iterator, :delete_if
+    # @yield build the tree if not cached
+    # @return [Interpreters::Base]
+    def interpreter_tree_for(type)
+      return yield unless %i[finder deleter].include?(type)
+      return yield if frozen?
+
+      @interpreter_tree_cache ||= {}
+      @interpreter_tree_cache[type] ||= yield
+    end
+
     # Return a list of the nodes in the AST.
     # The AST of a jsonpath query is a straight line, so this is expressible as an array.
     # The only part of the AST with branches is inside a filter selector, but that doesn't show up here.
@@ -82,6 +102,10 @@ module Janeway
     # the only part `pop` mutates. Nested contents (filter expressions,
     # function parameters, child-segment members) are shared with the original,
     # which is safe because the interpreter never mutates the AST.
+    #
+    # The tree cache is intentionally NOT shared with the dup: cached trees
+    # reference the original's top-level chain and are invalid for a dup that
+    # may later be popped.
     #
     # @return [Query]
     def dup


### PR DESCRIPTION
A mixed bag of minor performance improvements that aren't worth doing in separate PRs.

- `functions.rb:16-32` — `translate_iregex_to_ruby_regex` allocates a `chars` Array, scans it, then rebuilds via `.join`; direct `gsub` on the anchored region is simpler and cheaper (the pattern compiled at parse time makes this less hot after bucket 1, but still runs on dynamic patterns).
- `normalized_path.rb:35-41` — `NormalizedPath.escape` allocates `chars` Array, then for every char iterates 4 `Range` objects; replace fast-path with a single frozen anchored `Regexp`
- `lexer.rb:207,356,362,384,404,487` — `source[lexeme_start_p..(next_p - 1)]` repeated 6×; extract a `current_lexeme` helper
- `lexer.rb:136,152` — `[lexeme, lookahead].join` allocates Array + String per operator char; use `lexeme + lookahead`
- `lexer.rb:319-334` — `consume_four_hex_digits` builds an Array and joins; `String.new << c` avoids the Array. Also the `if hex_digits.size < 4` guard is unreachable → dead code.
- `ast/expression.rb:30-34` — `Expression#type` recomputes camelcase→underscore per call; cache per class
- `ast/name_selector.rb:25` — allocates `[' ', '.']` per `to_s` call
- `ast/expression.rb:41` — `Expression#indented` does `INDENT * level` per line; precompute an `INDENTS` array

**Result:** headline gain came from the `NormalizedPath.escape` fast-path: arity-4 `.each` over 50k leaves went from 293 → 103 ms per run (2.85×).

One more change:

Every call to `Enumerator#search`, `#each`, `#delete`, or `#delete_if` constructed a fresh `Interpreter`, which in turn built the whole interpreter tree from the AST via `query_to_interpreter_tree` — a walk that instantiates one interpreter object per AST node, wires up the `@next` chain, appends terminals, and rewrites child-segment branches. For queries called many times against the same `Query` object, this per-call setup cost dominated the fixed overhead of every operation.

Two of the four interpreter modes have block-free, stateless trees: `:finder` (`.search`) and `:deleter` (`.delete`). The tree that gets built for these modes is a pure function of the AST and depends on nothing that varies per call. It can be built once and shared.

The other two modes (`:iterator`, `:delete_if`) capture the caller's block in the terminal `Yielder` / `DeleteIf` interpreter — the tree differs per call, so those still build fresh.
