### PR TITLE
chore: delete dead code

### DIFF
--- a/lib/janeway/interpreters/index_selector_delete_if.rb
+++ b/lib/janeway/interpreters/index_selector_delete_if.rb
@@ -31,7 +31,6 @@ module Janeway
         index += input.size if index.negative? # yield positive index for the normalize path
         return unless @yield_proc.call(input[index], input, path + [index])
 
-        index += input.size if index.negative?
         input.delete_at(index) # returns nil if deleted value is nil, or if no value was deleted
         [result]
       rescue IndexError

--- a/lib/janeway/lexer.rb
+++ b/lib/janeway/lexer.rb
@@ -392,36 +392,6 @@ module Janeway
 
     # Consume an alphanumeric string.
     # If `ignore_keywords`, the result is always an :identifier token.
-    # Otherwise, keywords and function names will be recognized and tokenized as those types.
-    #
-    # @param ignore_keywords [Boolean]
-    def lex_identifier(ignore_keywords: false)
-      consume while alpha_numeric?(lookahead)
-
-      identifier = current_lexeme
-      type =
-        if KEYWORD_SET.include?(identifier) && !ignore_keywords
-          identifier.to_sym
-        elsif FUNCTIONS_SET.include?(identifier) && !ignore_keywords
-          :function
-        else
-          :identifier
-        end
-
-      Token.new(type, identifier, identifier, current_location)
-    end
-
-    # Parse an identifier string which is not within delimiters.
-    # The standard set of unicode code points are allowed.
-    # No character escapes are allowed.
-    # Keywords and function names are ignored in this context.
-    # @return [Token]
-    def lex_unescaped_identifier
-      consume while unescaped?(lookahead)
-      identifier = current_lexeme
-      Token.new(:identifier, identifier, identifier, current_location)
-    end
-
     # Return true if string matches the definition of "unescaped" from RFC9535:
     # unescaped     = %x20-21 /        ; see RFC 8259
     #                    ; omit 0x22 "
@@ -441,19 +411,6 @@ module Janeway
       when 0x5D..0xD7FF then true # remaining ascii and lots of unicode code points
         # omit surrogate code points
       when 0xE000..0x10FFFF then true # much more unicode code points
-      else false
-      end
-    end
-
-    def escapable?(char)
-      case char.ord
-      when 0x62 then true # backspace
-      when 0x66 then true # form feed
-      when 0x6E then true # line feed
-      when 0x72 then true # carriage return
-      when 0x74 then true # horizontal tab
-      when 0x2F then true # slash
-      when 0x5C then true # backslash
       else false
       end
     end

--- a/lib/janeway/parser.rb
+++ b/lib/janeway/parser.rb
@@ -78,12 +78,8 @@ module Janeway
 
     private
 
-    def pending_tokens?
-      @next_p < tokens.length
-    end
-
     def next_not_terminator?
-      next_token && next_token.type != :"\n" && next_token.type != :eof
+      next_token && next_token.type != :eof
     end
 
     # Make "next" token become "current" by moving the pointer


### PR DESCRIPTION
None of these are referenced anywhere in lib/ or spec/:

  * Lexer#lex_identifier and Lexer#lex_unescaped_identifier — orphaned tokenize helpers (the live path is lex_member_name_shorthand).
  * Lexer#escapable? — no callers.
  * Parser#pending_tokens? — no callers; also its :"\n" sibling in next_not_terminator? checks for a token type the lexer never produces, so the newline check is removed too.
  * IndexSelectorDeleteIf#interpret — the negative-index normalization was applied twice; the second application ran after the first had already made `index` non-negative.

48 lines gone, no behavior change; 1772 tests still green.