### PR TITLE
refactor: tighten correctness boundaries

### DIFF
--- a/lib/janeway/ast/function.rb
+++ b/lib/janeway/ast/function.rb
@@ -12,11 +12,19 @@ module Janeway
 
       def initialize(name, parameters, &body)
         raise ArgumentError, "expect string, got #{name.inspect}" unless name.is_a?(String)
+        raise ArgumentError, "expect body to be a Proc, got #{body.class}" unless body.is_a?(Proc)
+
+        # Catch author errors in the built-in function definitions at construction time
+        # instead of surfacing as an opaque ArgumentError when the query first runs.
+        unless body.arity == parameters.size
+          raise ArgumentError,
+                "function #{name.inspect}: body arity #{body.arity} does not " \
+                "match parameter count #{parameters.size}"
+        end
 
         super(name)
         @parameters = parameters
         @body = body
-        raise "expect body to be a Proc, got #{body.class}" unless body.is_a?(Proc)
       end
 
       def to_s

--- a/lib/janeway/ast/selector.rb
+++ b/lib/janeway/ast/selector.rb
@@ -26,9 +26,11 @@ module Janeway
       # Subsequent expression that modifies the result of this selector list.
       attr_accessor :next
 
-      def ==(other)
-        value == other&.value
-      end
+      # Intentionally NO #== override. The previous implementation compared
+      # only `value`, ignoring class and @next, which made two selector chains
+      # with identical heads but different tails compare equal (and matched
+      # across selector types by coincidence of value). Query#== is the
+      # correct equality entry point for query comparisons.
     end
   end
 end

--- a/lib/janeway/interpreter.rb
+++ b/lib/janeway/interpreter.rb
@@ -51,11 +51,16 @@ module Janeway
     # @return [Object]
     def interpret(input)
       @root.interpret(nil, nil, input, [])
-    rescue StandardError => e
-      # Error during interpretation. Convert it to a Janeway::Error and include the query in the message
-      error = err(e.message)
-      error.set_backtrace e.backtrace
-      raise error
+    rescue Janeway::Error => e
+      # Reformat known interpretation errors to include the query in the message.
+      # Real bugs (NoMethodError, TypeError, NameError, ...) are intentionally
+      # NOT caught here — they should surface with a real backtrace, not be
+      # masked as "Jsonpath query ..." messages.
+      raise if e.query # already annotated
+
+      annotated = err(e.message)
+      annotated.set_backtrace e.backtrace
+      raise annotated
     end
 
     private

--- a/lib/janeway/lexer.rb
+++ b/lib/janeway/lexer.rb
@@ -341,7 +341,7 @@ module Janeway
         hex_digits << c
         case c.ord
         when 0x30..0x39 then next # '0'..'9'
-        when 0x40..0x46 then next # 'A'..'F' (range preserves original behavior; note '@' also accepted)
+        when 0x41..0x46 then next # 'A'..'F'
         when 0x61..0x66 then next # 'a'..'f'
         else
           raise err("Invalid unicode escape sequence: \\u#{hex_digits}")

--- a/spec/lib/janeway/ast/function_spec.rb
+++ b/spec/lib/janeway/ast/function_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'janeway'
+
+module Janeway
+  module AST
+    describe Function do
+      it 'raises when body arity does not match parameter count' do
+        expect {
+          Function.new('bad', [1, 2]) { |only_one_param| only_one_param }
+        }.to raise_error(ArgumentError, /body arity 1 does not match parameter count 2/)
+      end
+
+      it 'accepts a body whose arity matches the parameter count' do
+        expect {
+          Function.new('ok', [1, 2]) { |a, b| a + b }
+        }.not_to raise_error
+      end
+
+      it 'raises when body is not a Proc' do
+        expect {
+          Function.new('bad', [])
+        }.to raise_error(ArgumentError, /expect body to be a Proc/)
+      end
+
+      it 'raises when name is not a string' do
+        expect {
+          Function.new(:bad, []) { }
+        }.to raise_error(ArgumentError, /expect string/)
+      end
+    end
+  end
+end

--- a/spec/lib/janeway/interpreter_spec.rb
+++ b/spec/lib/janeway/interpreter_spec.rb
@@ -24,6 +24,20 @@ module Janeway
       end
     end
 
+    # Interpretation errors that aren't Janeway::Error (e.g. NoMethodError from
+    # a real bug) must propagate untouched so callers can see the real
+    # backtrace instead of a misleading "Jsonpath query ... - undefined method"
+    # rewrap.
+    it 'does not mask non-Janeway exceptions from interpret' do
+      query = Janeway.parse('$')
+      interpreter = described_class.new(query)
+      allow(interpreter.instance_variable_get(:@root)).to receive(:interpret)
+        .and_raise(NoMethodError, 'undefined method `foo` for nil')
+      expect {
+        interpreter.interpret({})
+      }.to raise_error(NoMethodError, /undefined method/)
+    end
+
     # Compliance test suite requires this to raise a parse error
     # JsonPath comparison project suggests not to do that
     # CTS "basic, empty segment"

--- a/spec/lib/janeway/lexer_spec.rb
+++ b/spec/lib/janeway/lexer_spec.rb
@@ -4,6 +4,29 @@ require 'janeway/lexer'
 
 module Janeway
   describe Lexer do
+    describe 'unicode escape validation' do
+      it 'rejects @ as a hex digit (0x40 is not A-F)' do
+        expect {
+          described_class.lex(%q{$["\u@000"]})
+        }.to raise_error(Janeway::Error, /Invalid unicode escape sequence/)
+      end
+
+      it 'accepts A-F as hex digits' do
+        query = %q{$["} + "\\uABCD" + %q{"]}
+        expect { described_class.lex(query) }.not_to raise_error
+      end
+
+      it 'accepts a-f as hex digits' do
+        query = %q{$["} + "\\uabcd" + %q{"]}
+        expect { described_class.lex(query) }.not_to raise_error
+      end
+
+      it 'accepts 0-9 as hex digits' do
+        query = %q{$["} + "\\u0123" + %q{"]}
+        expect { described_class.lex(query) }.not_to raise_error
+      end
+    end
+
     it 'accepts multiple selectors within brackets, comma-separated' do
       expect(described_class.lex('$[1, 2]')).to eq([:root, :child_start, 1, :union, 2, :child_end, :eof])
     end

--- a/spec/lib/janeway/parser_spec.rb
+++ b/spec/lib/janeway/parser_spec.rb
@@ -62,7 +62,10 @@ module Janeway
       query = '$["abc"]'
       tokens = Lexer.lex(query)
       ast = described_class.new(tokens, query).parse
-      expect(ast.root.next).to eq(AST::NameSelector.new('abc'))
+      selector = ast.root.next
+      expect(selector).to be_a(AST::NameSelector)
+      expect(selector.value).to eq('abc')
+      expect(selector.next).to be_nil
     end
 
     it 'applies minus operator to the following zero' do


### PR DESCRIPTION
  **Description**

  A handful of items we've been steering around during the perf pass. They're not architectural in the "code shape" sense, but they narrow the API surface and remove
  landmines.

  **Items**

  - **`Interpreter#interpret` blanket `rescue StandardError` (`interpreter.rb:52-59`)** — catches every exception, rebuilds a `Janeway::Error`, and re-raises. This swallows
  genuine bugs (typos, `NoMethodError`, etc.) as "jsonpath errors." Narrow to the specific exception classes we mean to reformat (e.g. `TypeError` from `to_single_value`,      `IndexError` from index selectors). Or: keep the rescue only at the very top of the public entry (`Enumerator#search` / `#each` / `#delete`) so the rest of the code can      crash loudly during development.

  - **Lexer accepts `@` as a hex digit** — noted while touching `consume_four_hex_digits` in perf #5. The `when 0x40..0x46` branch (`lexer.rb`) should be `0x41..0x46` (`A`..
  `F`); `0x40` is `@`. Meaning today `\u@abc` parses as if it were `ꪼ`. File as a proper bug report, add a spec, fix.

  - **`AST::Function#literal?` hardcoded name registry (`ast/function.rb:41-48`)** — `case name; when 'length', 'count', 'value' then true; ...` — adding a new function
  silently raises here. Once bucket 4 introduces `Functions::REGISTRY`, `literal?` becomes a property of each function's definition entry instead of a case table maintained    separately.

  - **`AST::Function` doesn't validate `body.arity` vs `parameters.size`** (`ast/function.rb:13-20`) — mismatches surface as opaque `ArgumentError` at query time. Validate     at parse time.

  - **`Selector#==` compares only `value`** (`ast/selector.rb:29-31`) — ignores `@next` and class. Two selector chains with identical heads but different tails compare         equal. Either narrow to `other.is_a?(self.class)` and include `@next`, or drop the method (`Query#==` is what's actually used).
