### PR TITLE
refactor: deduplicate similar methods

### DIFF
--- a/lib/janeway/ast/binary_operator.rb
+++ b/lib/janeway/ast/binary_operator.rb
@@ -76,30 +76,31 @@ module Janeway
         operator_type == :logical
       end
 
+      # Single source of truth for what binary operators exist and how they
+      # render / classify. Adding a new operator here fills both call sites.
+      OPERATOR_META = {
+        and: { str: '&&', type: :logical },
+        or: { str: '||', type: :logical },
+        equal: { str: '==', type: :comparison },
+        not_equal: { str: '!=', type: :comparison },
+        less_than: { str: '<', type: :comparison },
+        less_than_or_equal: { str: '<=', type: :comparison },
+        greater_than: { str: '>', type: :comparison },
+        greater_than_or_equal: { str: '>=', type: :comparison },
+      }.freeze
+
       private
 
+      def operator_meta
+        OPERATOR_META.fetch(name) { raise "unknown binary operator #{name}" }
+      end
+
       def operator_to_s
-        case name
-        when :and then '&&'
-        when :equal then '=='
-        when :greater_than then '>'
-        when :greater_than_or_equal then '>='
-        when :less_than then '<'
-        when :less_than_or_equal then '<='
-        when :not_equal then '!='
-        when :or then '||'
-        else
-          raise "unknown binary operator #{name}"
-        end
+        operator_meta[:str]
       end
 
       def operator_type
-        case name
-        when :and, :or then :logical
-        when :equal, :not_equal, :greater_than, :greater_than_or_equal, :less_than, :less_than_or_equal then :comparison
-        else
-          raise "unknown binary operator #{name}"
-        end
+        operator_meta[:type]
       end
     end
   end

--- a/lib/janeway/ast/child_segment.rb
+++ b/lib/janeway/ast/child_segment.rb
@@ -18,9 +18,6 @@ module Janeway
 
       def_delegators :@value, :size, :first, :last, :each, :map, :empty?
 
-      # Subsequent expression that modifies the result of this selector list.
-      attr_accessor :next
-
       def initialize
         super([]) # @value holds the expressions in the selector
       end

--- a/lib/janeway/ast/current_node.rb
+++ b/lib/janeway/ast/current_node.rb
@@ -41,17 +41,7 @@ module Janeway
       #
       # @return [Boolean]
       def singular_query?
-        return true unless @next # there are no following selectors
-
-        selector_types = []
-        selector = @next
-        loop do
-          selector_types << selector.class
-          selector = selector.next
-          break unless selector
-        end
-        allowed = [AST::IndexSelector, AST::NameSelector]
-        selector_types.uniq.all? { allowed.include?(_1) }
+        chain_of?(AST::IndexSelector, AST::NameSelector)
       end
 
       # True if this is a bare current node operator, without a following expression

--- a/lib/janeway/ast/current_node.rb
+++ b/lib/janeway/ast/current_node.rb
@@ -29,9 +29,6 @@ module Janeway
     #
     # Construct accepts an optional Selector which will be applied to the "current" node
     class CurrentNode < Janeway::AST::Expression
-      # Subsequent expression that modifies the output of this expression
-      attr_accessor :next
-
       def to_s
         "@#{@next}"
       end

--- a/lib/janeway/ast/descendant_segment.rb
+++ b/lib/janeway/ast/descendant_segment.rb
@@ -16,9 +16,6 @@ module Janeway
     #   $..[*, *] All values, twice non-deterministic order
     #   $..[0, 1] Multiple segments
     class DescendantSegment < Janeway::AST::Selector
-      # Subsequent expression that modifies the result of this selector list.
-      attr_accessor :next
-
       def to_s
         "..#{@next&.to_s(dot_prefix: false)}"
       end

--- a/lib/janeway/ast/expression.rb
+++ b/lib/janeway/ast/expression.rb
@@ -20,8 +20,10 @@ module Janeway
       # Value provided by subclass constructor.
       attr_accessor :value
 
-      # Next expression in the AST, if any
-      attr_reader :next
+      # Next expression in the AST, if any. Writable so the parser can link
+      # nodes as it constructs the chain, and so Query#dup / #pop can rewire
+      # the top-level chain.
+      attr_accessor :next
 
       def initialize(val = nil)
         # don't set the instance variable if unused, because it makes the

--- a/lib/janeway/ast/expression.rb
+++ b/lib/janeway/ast/expression.rb
@@ -71,6 +71,22 @@ module Janeway
       def singular_query?
         false
       end
+
+      # True if every selector in the @next chain is one of the allowed classes.
+      # An empty chain (no @next) returns true. Extracted from the identical
+      # implementations that used to live in CurrentNode and RootNode.
+      #
+      # @param allowed_classes [Array<Class>]
+      # @return [Boolean]
+      def chain_of?(*allowed_classes)
+        selector = @next
+        while selector
+          return false unless allowed_classes.include?(selector.class)
+
+          selector = selector.next
+        end
+        true
+      end
     end
   end
 end

--- a/lib/janeway/ast/root_node.rb
+++ b/lib/janeway/ast/root_node.rb
@@ -26,17 +26,7 @@ module Janeway
       #
       # @return [Boolean]
       def singular_query?
-        return true unless @next # there are no following selectors
-
-        selector_types = []
-        selector = @next
-        loop do
-          selector_types << selector.class
-          selector = selector&.next
-          break unless selector
-        end
-        allowed = [AST::IndexSelector, AST::NameSelector]
-        selector_types.uniq.all? { allowed.include?(_1) }
+        chain_of?(AST::IndexSelector, AST::NameSelector)
       end
 
       # @param level [Integer]

--- a/lib/janeway/ast/root_node.rb
+++ b/lib/janeway/ast/root_node.rb
@@ -14,9 +14,6 @@ module Janeway
     #   $(? $.key1 == $.key2 )
     #
     class RootNode < Janeway::AST::Expression
-      # Subsequent expression that modifies the output of this expression
-      attr_accessor :next
-
       def to_s
         "$#{@next}"
       end

--- a/lib/janeway/ast/selector.rb
+++ b/lib/janeway/ast/selector.rb
@@ -23,9 +23,6 @@ module Janeway
     # Filter expressions ?<logical-expr> select certain children of an object or array, as in:
     #     $.store.book[?@.price < 10].title
     class Selector < Janeway::AST::Expression
-      # Subsequent expression that modifies the result of this selector list.
-      attr_accessor :next
-
       # Intentionally NO #== override. The previous implementation compared
       # only `value`, ignoring class and @next, which made two selector chains
       # with identical heads but different tails compare equal (and matched

--- a/lib/janeway/interpreters/filter_selector_interpreter.rb
+++ b/lib/janeway/interpreters/filter_selector_interpreter.rb
@@ -43,27 +43,9 @@ module Janeway
       # @param root [Array, Hash] the entire input
       # @param path [Array<String>] elements of normalized path to the current input
       def interpret_hash(input, root, path)
-        # Apply filter expressions to the input data
         node_list = []
-        input.each do |key, value|
-          # Run filter and interpret result
-          result = @expr.interpret(value, nil, root, [])
-          case result
-          when TrueClass then node_list << [key, value] # comparison test - pass
-          when FalseClass then nil # comparison test - fail
-          when Array then node_list << [key, value] unless result.empty? # existence test - node list
-          else
-            node_list << [key, value] # existence test. Null values here == success.
-          end
-        end
-        return node_list.map(&:last) unless @next
-
-        # Apply child selector to each node in the output node list
-        results = []
-        node_list.each do |key, value|
-          results.concat @next.interpret(value, input, root, path + [key])
-        end
-        results
+        input.each { |key, value| node_list << [key, value] if filter_match?(value, root) }
+        forward_matches(node_list, input, root, path)
       end
 
       # Interpret selector on the input.
@@ -71,28 +53,38 @@ module Janeway
       # @param root [Array, Hash] the entire input
       # @param path [Array<String>] elements of normalized path to the current input
       def interpret_array(input, root, path)
-        # Apply filter expressions to the input data
         node_list = []
-        input.each_with_index do |value, i|
-          # Run filter and interpret result
-          result = @expr.interpret(value, nil, root, [])
-          case result
-          when TrueClass then node_list << [i, value] # comparison test - pass
-          when FalseClass then nil # comparison test - fail
-          when Array then node_list << [i, value] unless result.empty? # existence test - node list
-          else
-            node_list << [i, value] # existence test. Null values here == success.
-          end
+        input.each_with_index { |value, i| node_list << [i, value] if filter_match?(value, root) }
+        forward_matches(node_list, input, root, path)
+      end
+
+      private
+
+      # Classify the result of running the filter expression against a value.
+      # Returns true if the value should be kept.
+      def filter_match?(value, root)
+        result = @expr.interpret(value, nil, root, [])
+        case result
+        when TrueClass then true    # comparison test - pass
+        when FalseClass then false  # comparison test - fail
+        when Array then !result.empty? # existence test - non-empty node list
+        else true                   # existence test - null / other values count as success
         end
+      end
+
+      # Given a node_list of [key_or_index, value] pairs, apply @next to each
+      # and concat the results. If no @next, return just the values.
+      def forward_matches(node_list, input, root, path)
         return node_list.map(&:last) unless @next
 
-        # Apply child selector to each node in the output node list
         results = []
-        node_list.each do |i, value|
-          results.concat @next.interpret(value, input, root, path + [i])
+        node_list.each do |key, value|
+          results.concat @next.interpret(value, input, root, path + [key])
         end
         results
       end
+
+      public
 
       # @return [Hash]
       def as_json


### PR DESCRIPTION
**Description**

Several places have two structurally-identical code paths where one abstraction is enough. Merging them shrinks the file and gives one place to fix future bugs.

**Items**
- `CurrentNode#singular_query?` and `RootNode#singular_query?` (`ast/current_node.rb:43-55` and `ast/root_node.rb:28-40`) are **line-for-line identical**. Extract to `Expression` (or a mixin) as `chain_of?(*allowed_classes)`. The manual `loop / break unless` walk is also awkward — a `while selector` is clearer.
- `BinaryOperator#operator_to_s` and `operator_type` (`ast/binary_operator.rb:82-103`) are two parallel case tables over the same symbols. One frozen `OPERATOR_META = { equal: { str: '==', type: :comparison }, ... }` hash replaces both and enforces they can never drift apart.
- `FilterSelectorInterpreter#interpret_hash` vs `#interpret_array` (`filter_selector_interpreter.rb:45-95`) — structurally identical (Enumerable pair + integer/string key). Also both build a `[[k,v],…]` pairs array up front only to remap it; when `@next` is nil the pairs array is wasted. One iteration helper covers both.
- `Expression#next` reader is shadowed by `attr_accessor :next` in most subclasses (`selector.rb:27`, `child_segment.rb:22`, `current_node.rb:33`, `descendant_segment.rb:20`, `root_node.rb:18`). Declare `attr_accessor :next` once in `Expression` and delete the five duplicates.

