### PR TITLE
refactor: fix AST separation-of-concern

### DIFF
--- a/lib/janeway/ast/array_slice_selector.rb
+++ b/lib/janeway/ast/array_slice_selector.rb
@@ -22,6 +22,11 @@ module Janeway
     # "explicit" arguments, since they're interpreted differently.
     #
     class ArraySliceSelector < Janeway::AST::Selector
+      # Raw start / end / step values from the query source. Any of them may
+      # be nil, meaning "use the default for the current step direction" —
+      # the interpreter resolves that.
+      attr_reader :start, :end, :step
+
       # @param start [Integer, nil]
       # @param end_ [Integer, nil]
       # @param step [Integer, nil]
@@ -40,100 +45,11 @@ module Janeway
           raise Error, "Array slice selector value too large: #{arg.inspect}" if arg > INTEGER_MAX
         end
 
-        # Nil values are kept to indicate that the "default" values is to be used.
+        # Nil values are kept to indicate that the default value should be used.
         # The interpreter selects the actual values.
         @start = start
         @end = end_
         @step = step
-      end
-
-      # Return the step size to use for stepping through the array.
-      # Defaults to 1 if it was not given to the constructor.
-      #
-      # @return [Integer]
-      def step
-        # The iteration behavior of jsonpath does not match that of ruby Integer#step.
-        # Support the behavior of Integer#step, which needs this:
-        #   1. for stepping forward between positive numbers, use a positive number
-        #   2. for stepping backward between positive numbers, use a negative number
-        #   3. for stepping backward from positive to negative, use a negative number
-        #   4. for stepping backward from negative to negative, use a positive number
-        # Case #4 has to be detected and the sign of step inverted
-        @step || 1
-      end
-
-      # Return the start index to use for stepping through the array, based on a specified array size
-      #
-      # @param input_size [Integer]
-      # @return [Integer]
-      def upper_index(input_size)
-        calculate_index_values(input_size).last
-      end
-
-      # Return the end index to use for stepping through the array, based on a specified array size
-      # End index is calculated to omit the final index value, as per the RFC.
-      #
-      # @param input_size [Integer]
-      # @return [Integer]
-      def lower_index(input_size)
-        calculate_index_values(input_size).first
-      end
-
-      # Assign lower and upper bounds to instance variables, based on the input array size.
-      # @see https://www.rfc-editor.org/rfc/rfc9535.html#section-2.3.4.2.2-3
-      #
-      # @param input_size [Integer]
-      def calculate_index_values(input_size)
-        if step >= 0
-          start = @start || 0
-          end_ = @end || input_size
-        else
-          start = @start || (input_size - 1)
-          end_ = @end || ((-1 * input_size) - 1)
-        end
-
-        bounds(start, end_, step, input_size)
-      end
-
-      # NOTE: Conversion of start:end:step to array indexes is defined as pseudocode
-      # in the IETF spec.
-      # The methods #normalize and #bounds are ruby implementations of that code.
-      # Don't make changes here without referring to the original code in the spec.
-      # @see https://www.rfc-editor.org/rfc/rfc9535.html#section-2.3.4.2.2-6
-
-      # IETF: Slice expression parameters start and end are not directly usable
-      # as slice bounds and must first be normalized.
-      #
-      # @param index [Integer]
-      # @param len [Integer]
-      def normalize(index, len)
-        return index if index >= 0
-
-        len + index
-      end
-
-      # IETF: Slice expression parameters start and end are used to derive
-      # slice bounds lower and upper. The direction of the iteration, defined
-      # by the sign of step, determines which of the parameters is the lower
-      # bound and which is the upper bound:¶
-      # @see https://www.rfc-editor.org/rfc/rfc9535.html#section-2.3.4.2.2-9
-      # @param start [Integer] start index, normalized
-      # @param end_ [Integer] end index, normalized
-      # @param step [Integer] step value
-      # @param len [Integer] length of input array
-      def bounds(start, end_, step, len)
-        n_start = normalize(start, len)
-        n_end = normalize(end_, len)
-
-        if step >= 0
-          lower = n_start.clamp(0, len)
-          upper = n_end.clamp(0, len)
-        else
-          upper = n_start.clamp(-1, len - 1)
-          lower = n_end.clamp(-1, len - 1)
-        end
-
-        [lower, upper]
       end
 
       # @param brackets [Boolean] add surrounding brackets if true

--- a/lib/janeway/ast/binary_operator.rb
+++ b/lib/janeway/ast/binary_operator.rb
@@ -5,48 +5,31 @@ module Janeway
     # AST node for binary operators:
     #   == != <= >= < > || &&
     class BinaryOperator < Janeway::AST::Expression
-      attr_reader :name, :left, :right
+      attr_reader :name
+      attr_accessor :left, :right
 
       def initialize(operator, left = nil, right = nil)
         super(nil)
         raise ArgumentError, "expect symbol, got #{operator.inspect}" unless operator.is_a?(Symbol)
 
         @name = operator # eg. :equal
-        self.left = left if left
-        self.right = right if right
+        @left = left
+        @right = right
       end
 
-      # Set the left-hand-side expression
-      # @param expr [AST::Expression]
-      def left=(expr)
-        if comparison_operator? && !(expr.literal? || expr.singular_query?)
-          raise Error, "Expression #{expr} does not produce a singular value for #{operator_to_s} comparison"
-        elsif comparison_operator? && expr.is_a?(AST::Function) && !expr.literal?
-          msg = "Function #{expr} returns a non-comparable value which is not usable for #{operator_to_s} comparison"
-          raise Error, msg
-        end
+      # Validate the currently-set left and right operands as a well-formed
+      # binary expression. Called by the parser once both sides are assigned —
+      # the previous per-setter validation was order-dependent (left=
+      # couldn't see right and vice-versa) and missed the both-literal case
+      # when the parser assigned left first.
+      #
+      # @raise [Janeway::Error] on any semantic error
+      def validate!
+        raise Error, 'BinaryOperator requires both left and right' unless @left && @right
 
-        # Compliance test suite requires error for this, but don't have go so far as to bar every literal
-        if expr.is_a?(Boolean) && right.is_a?(Boolean)
-          raise Error, "Literal \"#{expr}\" must be compared to an expression, not another literal (\"#{left}\")"
-        end
-
-        @left = expr
-      end
-
-      # Set the left-hand-side expression
-      # @param expr [AST::Expression]
-      def right=(expr)
-        if comparison_operator? && !(expr.literal? || expr.singular_query?)
-          raise Error, "Expression #{expr} does not produce a singular value for #{operator_to_s} comparison"
-        end
-
-        # Compliance test suite requires error for this, but don't have go so far as to bar every literal
-        if expr.is_a?(Boolean) && left.is_a?(Boolean)
-          raise Error, "Literal \"#{expr}\" must be compared to an expression, not another literal (\"#{left}\")"
-        end
-
-        @right = expr
+        validate_side(@left)
+        validate_side(@right)
+        validate_pair
       end
 
       def to_s
@@ -101,6 +84,28 @@ module Janeway
 
       def operator_type
         operator_meta[:type]
+      end
+
+      # Per-side checks that apply to either operand of a comparison.
+      def validate_side(expr)
+        return unless comparison_operator?
+
+        unless expr.literal? || expr.singular_query?
+          raise Error, "Expression #{expr} does not produce a singular value for #{operator_to_s} comparison"
+        end
+        if expr.is_a?(AST::Function) && !expr.literal?
+          raise Error,
+                "Function #{expr} returns a non-comparable value which is not usable for #{operator_to_s} comparison"
+        end
+      end
+
+      # Checks that need both sides in scope.
+      def validate_pair
+        return unless @left.is_a?(Boolean) && @right.is_a?(Boolean)
+
+        # Compliance test suite requires error for this, but don't go so far as to bar every literal.
+        raise Error,
+              "Literal \"#{@right}\" must be compared to an expression, not another literal (\"#{@left}\")"
       end
     end
   end

--- a/lib/janeway/ast/function.rb
+++ b/lib/janeway/ast/function.rb
@@ -5,26 +5,28 @@ require_relative 'expression'
 module Janeway
   module AST
     # Represents a JSONPath built-in function.
+    #
+    # This is pure structure: name + parameters. The body / literal_return
+    # metadata lives in Functions::REGISTRY (looked up by name), so AST nodes
+    # don't drag closures over the parser's binding.
     class Function < Janeway::AST::Expression
       alias name value
 
-      attr_reader :parameters, :body
+      attr_reader :parameters
 
-      def initialize(name, parameters, &body)
+      def initialize(name, parameters)
         raise ArgumentError, "expect string, got #{name.inspect}" unless name.is_a?(String)
-        raise ArgumentError, "expect body to be a Proc, got #{body.class}" unless body.is_a?(Proc)
 
-        # Catch author errors in the built-in function definitions at construction time
-        # instead of surfacing as an opaque ArgumentError when the query first runs.
-        unless body.arity == parameters.size
+        spec = Functions::REGISTRY[name]
+        raise ArgumentError, "unknown function #{name.inspect}" unless spec
+        unless spec[:arity] == parameters.size
           raise ArgumentError,
-                "function #{name.inspect}: body arity #{body.arity} does not " \
+                "function #{name.inspect}: declared arity #{spec[:arity]} does not " \
                 "match parameter count #{parameters.size}"
         end
 
         super(name)
         @parameters = parameters
-        @body = body
       end
 
       def to_s
@@ -47,12 +49,7 @@ module Janeway
 
       # True if the function's return value is a literal
       def literal?
-        case name
-        when 'length', 'count', 'value' then true
-        when 'search', 'match' then false
-        else
-          raise "Unknown jsonpath function #{name}"
-        end
+        Functions::REGISTRY.fetch(name)[:literal_return]
       end
     end
   end

--- a/lib/janeway/functions.rb
+++ b/lib/janeway/functions.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 require_relative 'ast/function'
+require_relative 'ast/string_type'
 
 module Janeway
-  # Mixin to provide JSONPath function handlers for Parser
+  # Mixin to provide JSONPath function handlers for Parser, plus the shared
+  # I-Regexp translation helper and the built-in function registry.
   module Functions
     # Convert IRegexp format to ruby regexp equivalent, following the instructions in rfc9485.
     # @see https://www.rfc-editor.org/rfc/rfc9485.html#name-pcre-re2-and-ruby-regexps
@@ -35,6 +37,7 @@ module Janeway
       regex_str = anchor ? format('\A(?:%s)\z', chars.join) : chars.join
       Regexp.new(regex_str)
     end
+    module_function :translate_iregex_to_ruby_regex
 
     # All jsonpath function parameters are one of these accepted types.
     # Parse the function parameter and return the result.
@@ -54,10 +57,80 @@ module Janeway
       consume
       result
     end
+
+    # Build a match/search body. When the pattern is a StringType literal we
+    # compile the regex once at parse time (see perf pass, commit fd8b92a).
+    # Otherwise fall back to per-call compilation.
+    def self.build_regex_body(parameters, anchor:)
+      literal_regexp =
+        if parameters[1].is_a?(AST::StringType)
+          begin
+            translate_iregex_to_ruby_regex(parameters[1].value, anchor: anchor)
+          rescue RegexpError
+            nil # fall back to per-call compilation, which will raise at eval time
+          end
+        end
+
+      if literal_regexp
+        ->(str, _pattern) { str.is_a?(String) && literal_regexp.match?(str) }
+      else
+        lambda do |str, pattern|
+          if str.is_a?(String) && pattern.is_a?(String)
+            translate_iregex_to_ruby_regex(pattern, anchor: anchor).match?(str)
+          else
+            false
+          end
+        end
+      end
+    end
+
+    # Metadata + body builder for every built-in JSONPath function.
+    #
+    #   arity          — number of parameters
+    #   literal_return — true when the result is a literal (see RFC 9535
+    #                    well-typedness of function extensions)
+    #   build          — proc that takes the parsed `parameters` list and
+    #                    returns the body proc (parameters allow per-instance
+    #                    optimization, e.g. literal-regex compilation)
+    REGISTRY = {
+      'count' => {
+        arity: 1,
+        literal_return: true,
+        build: ->(_) { ->(nodes) { nodes.is_a?(Array) ? nodes.size : 1 } },
+      },
+      'length' => {
+        arity: 1,
+        literal_return: true,
+        build: lambda { |_|
+          lambda { |value|
+            [Array, Hash, String].include?(value.class) ? value.size : :nothing
+          }
+        },
+      },
+      'value' => {
+        arity: 1,
+        literal_return: true,
+        build: lambda { |_|
+          lambda { |nodes|
+            nodes.is_a?(Array) && nodes.size == 1 ? nodes.first : :nothing
+          }
+        },
+      },
+      'match' => {
+        arity: 2,
+        literal_return: false,
+        build: ->(parameters) { Functions.build_regex_body(parameters, anchor: true) },
+      },
+      'search' => {
+        arity: 2,
+        literal_return: false,
+        build: ->(parameters) { Functions.build_regex_body(parameters, anchor: false) },
+      },
+    }.freeze
   end
 end
 
-# Require function definitions
+# Require function parse-method definitions
 Dir.children("#{__dir__}/functions/").each do |path|
   require_relative "functions/#{path[0..-4]}"
 end

--- a/lib/janeway/functions/count.rb
+++ b/lib/janeway/functions/count.rb
@@ -29,14 +29,7 @@ module Janeway
       raise Error, "Invalid parameter - count() expects node list, got #{arg.value.inspect}" if arg.literal?
       raise Error, 'Too many parameters for count() function call' unless current.type == :group_end
 
-      # Define function body
-      AST::Function.new('count', parameters) do |node_list|
-        if node_list.is_a?(Array)
-          node_list.size
-        else
-          1 # the count of a non-empty singular nodelist such as count(@) is always 1.
-        end
-      end
+      AST::Function.new('count', parameters)
     end
   end
 end

--- a/lib/janeway/functions/length.rb
+++ b/lib/janeway/functions/length.rb
@@ -21,18 +21,7 @@ module Janeway
       end
       raise err('Too many parameters for length() function call') unless current.type == :group_end
 
-      # Meaning of return value depends on the JSON type:
-      #   * string - number of Unicode scalar values in the string.
-      #   * array -  number of elements in the array.
-      #   * object - number of members in the object.
-      # For any other argument value, the result is the special result Nothing.
-      AST::Function.new('length', parameters) do |value|
-        if [Array, Hash, String].include?(value.class)
-          value.size
-        else
-          :nothing
-        end
-      end
+      AST::Function.new('length', parameters)
     end
   end
 end

--- a/lib/janeway/functions/match.rb
+++ b/lib/janeway/functions/match.rb
@@ -52,31 +52,9 @@ module Janeway
       parameters << parse_function_parameter
       raise Error, 'Too many parameters for match() function call' unless current.type == :group_end
 
-      # If the pattern is a string literal, compile the regex once at parse time
-      # instead of recompiling it on every row.
-      literal_regexp =
-        if parameters[1].is_a?(AST::StringType)
-          begin
-            translate_iregex_to_ruby_regex(parameters[1].value)
-          rescue RegexpError
-            nil # fall back to per-call compilation, which will raise at eval time
-          end
-        end
-
-      if literal_regexp
-        AST::Function.new('match', parameters) do |str, _str_iregexp|
-          str.is_a?(String) ? literal_regexp.match?(str) : false
-        end
-      else
-        AST::Function.new('match', parameters) do |str, str_iregexp|
-          if str.is_a?(String) && str_iregexp.is_a?(String)
-            regexp = translate_iregex_to_ruby_regex(str_iregexp)
-            regexp.match?(str)
-          else
-            false # result defined by RFC9535
-          end
-        end
-      end
+      # Body (including literal-regex fast path) is supplied by
+      # Functions::REGISTRY at FunctionInterpreter construction time.
+      AST::Function.new('match', parameters)
     end
   end
 end

--- a/lib/janeway/functions/search.rb
+++ b/lib/janeway/functions/search.rb
@@ -47,31 +47,9 @@ module Janeway
       parameters << parse_function_parameter
       raise Error, 'Too many parameters for match() function call' unless current.type == :group_end
 
-      # If the pattern is a string literal, compile the regex once at parse time
-      # instead of recompiling it on every row.
-      literal_regexp =
-        if parameters[1].is_a?(AST::StringType)
-          begin
-            translate_iregex_to_ruby_regex(parameters[1].value, anchor: false)
-          rescue RegexpError
-            nil # fall back to per-call compilation, which will raise at eval time
-          end
-        end
-
-      if literal_regexp
-        AST::Function.new('search', parameters) do |str, _str_iregexp|
-          str.is_a?(String) ? literal_regexp.match?(str) : false
-        end
-      else
-        AST::Function.new('search', parameters) do |str, str_iregexp|
-          if str.is_a?(String) && str_iregexp.is_a?(String)
-            regexp = translate_iregex_to_ruby_regex(str_iregexp, anchor: false)
-            regexp.match?(str)
-          else
-            false # result defined by RFC9535
-          end
-        end
-      end
+      # Body (including literal-regex fast path) is supplied by
+      # Functions::REGISTRY at FunctionInterpreter construction time.
+      AST::Function.new('search', parameters)
     end
   end
 end

--- a/lib/janeway/functions/value.rb
+++ b/lib/janeway/functions/value.rb
@@ -36,13 +36,7 @@ module Janeway
       parameters = [parse_function_parameter]
       raise Error, 'Too many parameters for value() function call' unless current.type == :group_end
 
-      AST::Function.new('value', parameters) do |nodes|
-        if nodes.is_a?(Array) && nodes.size == 1
-          nodes.first
-        else
-          :nothing
-        end
-      end
+      AST::Function.new('value', parameters)
     end
   end
 end

--- a/lib/janeway/interpreters/array_slice_selector_delete_if.rb
+++ b/lib/janeway/interpreters/array_slice_selector_delete_if.rb
@@ -27,19 +27,13 @@ module Janeway
       # @return [Array]
       def interpret(input, _parent, _root, path)
         return [] unless input.is_a?(Array)
-        return [] if selector&.step&.zero? # RFC: When step is 0, no elements are selected.
+        return [] if effective_step.zero? # RFC: When step is 0, no elements are selected.
 
-        # Calculate the upper and lower indices of the target range
-        lower = selector.lower_index(input.size)
-        upper = selector.upper_index(input.size)
-
-        # Convert bounds and step to index values.
-        # Omit the final index, since no value is collected for that.
-        # Delete indexes from largest to smallest, so that deleting an index does
-        # not change the remaining indexes
+        # Delete matching indexes from largest to smallest so that deletion
+        # does not shift the remaining indexes.
+        indexes = index_range(input.size)
         results = []
-        if selector.step.positive?
-          indexes = lower.step(to: upper - 1, by: selector.step).to_a
+        if effective_step.positive?
           indexes.reverse_each do |i|
             next unless @yield_proc.call(input[i], input, path + [i])
 
@@ -47,7 +41,6 @@ module Janeway
           end
           results.reverse
         else
-          indexes = upper.step(to: lower + 1, by: selector.step).to_a
           indexes.each do |i|
             next unless @yield_proc.call(input[i], input, path + [i])
 

--- a/lib/janeway/interpreters/array_slice_selector_interpreter.rb
+++ b/lib/janeway/interpreters/array_slice_selector_interpreter.rb
@@ -17,19 +17,9 @@ module Janeway
       # @return [Array]
       def interpret(input, _parent, root, path)
         return [] unless input.is_a?(Array)
-        return [] if selector&.step&.zero? # RFC: When step is 0, no elements are selected.
+        return [] if effective_step.zero? # RFC: When step is 0, no elements are selected.
 
-        # Calculate the upper and lower indices of the target range
-        lower = selector.lower_index(input.size)
-        upper = selector.upper_index(input.size)
-
-        # Collect real index values. Omit the final index, since no value is collected for that.
-        indexes =
-          if selector.step.positive?
-            lower.step(to: upper - 1, by: selector.step).to_a
-          else
-            upper.step(to: lower + 1, by: selector.step).to_a
-          end
+        indexes = index_range(input.size)
         return indexes.map { |i| input[i] } unless @next
 
         # Apply child selector to each node in the output node list
@@ -43,6 +33,59 @@ module Janeway
       # @return [Hash]
       def as_json
         { type: type, value: node.to_s, next: @next&.as_json }.compact
+      end
+
+      protected
+
+      # Concrete list of source-array indexes this slice selects, in
+      # iteration order. Consumed by both this interpreter and
+      # ArraySliceSelectorDeleteIf.
+      #
+      # @param input_size [Integer]
+      # @return [Array<Integer>]
+      def index_range(input_size)
+        lower, upper = bounds(input_size)
+        if effective_step.positive?
+          lower.step(to: upper - 1, by: effective_step).to_a
+        else
+          upper.step(to: lower + 1, by: effective_step).to_a
+        end
+      end
+
+      # Effective step: raw @step from the AST, or 1 if unspecified.
+      def effective_step
+        selector.step || 1
+      end
+
+      # Compute lower/upper bounds for the slice given the input array size.
+      # RFC 9535 pseudocode lives here (formerly on AST::ArraySliceSelector).
+      # @see https://www.rfc-editor.org/rfc/rfc9535.html#section-2.3.4.2.2
+      #
+      # @param input_size [Integer]
+      # @return [Array(Integer, Integer)] [lower, upper]
+      def bounds(input_size)
+        if effective_step >= 0
+          start = selector.start || 0
+          end_ = selector.end || input_size
+        else
+          start = selector.start || (input_size - 1)
+          end_ = selector.end || ((-1 * input_size) - 1)
+        end
+
+        n_start = normalize(start, input_size)
+        n_end = normalize(end_, input_size)
+
+        if effective_step >= 0
+          [n_start.clamp(0, input_size), n_end.clamp(0, input_size)]
+        else
+          [n_end.clamp(-1, input_size - 1), n_start.clamp(-1, input_size - 1)]
+        end
+      end
+
+      # IETF: slice parameters must be normalized before use as bounds —
+      # negative values count from the end of the array.
+      def normalize(index, len)
+        index >= 0 ? index : len + index
       end
     end
   end

--- a/lib/janeway/interpreters/function_interpreter.rb
+++ b/lib/janeway/interpreters/function_interpreter.rb
@@ -22,6 +22,10 @@ module Janeway
       def initialize(function)
         super
         @params = function.parameters.map { |param| TreeConstructor.ast_node_to_interpreter(param) }
+        # Build the function body from the registry. This is the point at
+        # which per-instance specialization happens — e.g. match/search
+        # compile a literal regex once, capturing it in the closure.
+        @body = Functions::REGISTRY.fetch(function.name)[:build].call(function.parameters)
       end
 
       # @param input [Array, Hash] the results of processing so far
@@ -30,7 +34,7 @@ module Janeway
       # @param _path [Array<String>] elements of normalized path to the current input
       def interpret(input, _parent, root, _path)
         params = interpret_function_parameters(@params, input, root)
-        function.body.call(*params)
+        @body.call(*params)
       end
 
       # Evaluate the expressions in the parameter list to make the parameter values

--- a/lib/janeway/parser.rb
+++ b/lib/janeway/parser.rb
@@ -536,6 +536,7 @@ module Janeway
 
       consume
       op.right = parse_expr_recursively(op_precedence)
+      op.validate!
 
       op
     end

--- a/spec/lib/janeway/ast/function_spec.rb
+++ b/spec/lib/janeway/ast/function_spec.rb
@@ -5,28 +5,33 @@ require 'janeway'
 module Janeway
   module AST
     describe Function do
-      it 'raises when body arity does not match parameter count' do
+      it 'raises when the parameter count does not match the registered arity' do
         expect {
-          Function.new('bad', [1, 2]) { |only_one_param| only_one_param }
-        }.to raise_error(ArgumentError, /body arity 1 does not match parameter count 2/)
+          Function.new('count', [1, 2])
+        }.to raise_error(ArgumentError, /declared arity 1 does not match parameter count 2/)
       end
 
-      it 'accepts a body whose arity matches the parameter count' do
+      it 'accepts the correct number of parameters' do
         expect {
-          Function.new('ok', [1, 2]) { |a, b| a + b }
+          Function.new('count', [1])
         }.not_to raise_error
       end
 
-      it 'raises when body is not a Proc' do
+      it 'raises when the function name is not in the registry' do
         expect {
-          Function.new('bad', [])
-        }.to raise_error(ArgumentError, /expect body to be a Proc/)
+          Function.new('not_a_real_function', [])
+        }.to raise_error(ArgumentError, /unknown function/)
       end
 
       it 'raises when name is not a string' do
         expect {
-          Function.new(:bad, []) { }
+          Function.new(:count, [1])
         }.to raise_error(ArgumentError, /expect string/)
+      end
+
+      it 'reports literal? based on the registry entry' do
+        expect(Function.new('count', [1]).literal?).to be(true)
+        expect(Function.new('match', %w[x y]).literal?).to be(false)
       end
     end
   end


### PR DESCRIPTION
**Description**

The AST is supposed to be pure structure — every other selector kind puts execution in `Interpreters::*`. Three places break this:

- `AST::ArraySliceSelector` (`ast/array_slice_selector.rb:69-137`) hosts the RFC 9535 slicing math: `normalize`, `bounds`, `calculate_index_values`, `upper_index`, `lower_index`. These are pure computation over the AST's own fields, so their existence in AST-land is arguably harmless — but they're inconsistent with the rest of the codebase, and `ArraySliceSelectorInterpreter` reaches back into the AST to call them.
- `AST::Function` (`ast/function.rb:13-20`) stores an executable `Proc` created inside the parser (`parser.rb:parse_function_match`, etc.). Every parsed query drags a closure over the parser's binding. The `FunctionInterpreter` at `interpreters/function_interpreter.rb` already exists — the Proc belongs there, keyed by function name.
- `AST::BinaryOperator` setters (`ast/binary_operator.rb:21-50`) run semantic validation at `left=`/`right=` time, coupling AST assignment to the parser's calling order (`.left =` before `.right =` misses the "two-literal comparison" case). Validation belongs either in the parser (right after construction) or in a `validate!` method invoked after both sides are set.

**Approach** (one item = one commit)
1. Move `ArraySliceSelector`'s bounds math into `ArraySliceSelectorInterpreter`. The AST holds `start`, `end`, `step`; the interpreter computes the rest.
2. Register function bodies in a `Functions::REGISTRY = { 'match' => ->(...) {...}, ... }` hash inside the `Functions` module. `AST::Function` stores name + parameters only; `FunctionInterpreter` looks up the body at construction.
3. Move `BinaryOperator` validation into a single `validate!(left, right)` call the parser makes after both sides are set.
