### PR TITLE
refactor: nerf god methods and eliminate law-of-demeter violations

### DIFF
--- a/lib/janeway/enumerator.rb
+++ b/lib/janeway/enumerator.rb
@@ -134,9 +134,7 @@ module Janeway
     # @!visibility private
     # @return [Object, Object, String] parent object (Hash / Array), key/index (String / Integer), path to parent
     def find_parent
-      # Make a Query that points to the target's parent
-      parent_query = @query.dup
-      selector = parent_query.pop # returns a name or index selector
+      parent_query, leaf = @query.parent_query
 
       # Find parent element, give up if parent does not exist
       results = Interpreter.new(parent_query).interpret(@input)
@@ -146,7 +144,7 @@ module Janeway
       else raise "query #{parent_query} matched multiple elements!" # not possible for singular query
       end
 
-      [parent, selector.value, parent_query.to_s]
+      [parent, leaf.value, parent_query.to_s]
     end
 
     # Insert value into hash at the given key

--- a/lib/janeway/interpreter.rb
+++ b/lib/janeway/interpreter.rb
@@ -67,48 +67,60 @@ module Janeway
 
     # Build a tree of interpreter classes based on the query's abstract syntax tree.
     #
-    # Child segments require special handling.
-    # See the detailed explanation at the end of this file.
+    # Four phases, one per private helper:
+    #   1. build_interpreters  — one interpreter per AST node
+    #   2. append_terminal     — Yielder / Deleter / DeleteIf for the caller's mode
+    #   3. link_next_pointers  — wire each interpreter to the next one
+    #   4. rewire_child_segments — push tail selectors into each ChildSegmentInterpreter
+    #      (branch rewrite explained in the docstring at the end of this file)
     #
     # @return [Interpreters::RootNodeInterpreter]
     def query_to_interpreter_tree(query, &block)
-      # Build an interpreter for each selector
-      interpreters =
-        query.node_list.map do |node|
-          Interpreters::TreeConstructor.ast_node_to_interpreter(node)
-        end
+      interpreters = build_interpreters(query)
+      append_terminal(interpreters, &block)
+      link_next_pointers(interpreters)
+      rewire_child_segments(interpreters)
+    end
 
-      # Append iterotor / deleter as needed, to support #each, #delete operations
+    # Phase 1: one interpreter per AST node in the query's top-level chain.
+    def build_interpreters(query)
+      query.node_list.map { |node| Interpreters::TreeConstructor.ast_node_to_interpreter(node) }
+    end
+
+    # Phase 2: append the terminal interpreter that matches the caller's mode.
+    # Deleter / delete_if REPLACE the last selector (the terminal semantics
+    # live in the leaf itself); iterator APPENDS a Yielder after it.
+    def append_terminal(interpreters, &block)
       case @type
       when :iterator then interpreters.push(Yielder.new(&block))
-      when :deleter then interpreters.push make_deleter(interpreters.pop)
-      when :delete_if then interpreters.push make_delete_if(interpreters.pop, &block)
+      when :deleter then interpreters.push(make_deleter(interpreters.pop))
+      when :delete_if then interpreters.push(make_delete_if(interpreters.pop, &block))
       end
+    end
 
-      # Link interpreters together
+    # Phase 3: link `.next` from each interpreter to the following one.
+    def link_next_pointers(interpreters)
       interpreters.each_with_index do |node, i|
         node.next = interpreters[i + 1]
       end
+    end
 
-      # Child segments which contain multiple selectors are branches in the interpreter tree.
-      #
-      # For every child segment, remove all following interpreters and push
-      # them "inside" the child segment interpreter.
-      #
-      # Work backwards in case there are multiple child segments.
-      # For full explanation see the explanation at the end of this file.
-      selectors = []
+    # Phase 4: for every ChildSegmentInterpreter, remove the interpreters that
+    # follow it in the flat chain and push them into the child segment as
+    # branches. Work backwards so nested child segments compose correctly.
+    # @return [Interpreters::Base] root of the resulting tree
+    def rewire_child_segments(interpreters)
+      pending = []
       interpreters.reverse_each do |node|
         if node.is_a?(Interpreters::ChildSegmentInterpreter)
           node.next = nil
-          node.push(selectors.pop) until selectors.empty?
-          selectors = [node]
+          node.push(pending.pop) until pending.empty?
+          pending = [node]
         else
-          selectors << node
+          pending << node
         end
       end
-
-      selectors.last
+      pending.last
     end
 
     # Make a Deleter that will delete the results matched by a Selector.

--- a/lib/janeway/lexer.rb
+++ b/lib/janeway/lexer.rb
@@ -114,7 +114,7 @@ module Janeway
         elsif digit?(c)
           lex_number
         elsif name_first_char?(c)
-          lex_member_name_shorthand(ignore_keywords: tokens.last&.type == :dot)
+          lex_member_name_shorthand(ignore_keywords: previous_token_type == :dot)
         end
       raise err("Unknown character: #{c.inspect}") unless token
 
@@ -183,6 +183,14 @@ module Janeway
     # @return [String] source substring for the lexeme currently being built
     def current_lexeme
       source[lexeme_start_p..(next_p - 1)]
+    end
+
+    # Type of the most-recently-emitted token, or nil if none.
+    # Named lookback for the two context-sensitive lexing decisions
+    # (identifier-in-brackets rejection; keyword ignore after `.`).
+    # @return [Symbol, nil]
+    def previous_token_type
+      @tokens.last&.type
     end
 
     # @param delimiter [String] eg. ' or "
@@ -455,7 +463,7 @@ module Janeway
     def lex_member_name_shorthand(ignore_keywords: false)
       # Abort if name is preceded by child_start.  Catches non-delimited identifiers in brackets,
       # eg.  $["key"] is allowed, but $[key] is not
-      raise err('Identifier within brackets must be surrounded by quotes') if @tokens.last&.type == :child_start
+      raise err('Identifier within brackets must be surrounded by quotes') if previous_token_type == :child_start
 
       consume while name_char?(lookahead)
       identifier = current_lexeme

--- a/lib/janeway/parser.rb
+++ b/lib/janeway/parser.rb
@@ -28,7 +28,20 @@ module Janeway
       %I[identifier number string true false nil function if while root current_node]
       .each_with_object({}) { |t, h| h[t] = true }.freeze
     TERMINATOR_TYPES = %I[child_end union eof].each_with_object({}) { |t, h| h[t] = true }.freeze
-    NEWLINE_OR_EOF_TYPES = { :"\n" => true, eof: true }.freeze
+
+    # O(1) dispatch table for determine_parsing_function's type-driven cases.
+    # Sits next to the PARSE_METHOD_TYPES set (the other type branch) so both
+    # are visible when adding a new token type.
+    PARSE_DISPATCH_BY_TYPE = {
+      group_start: :parse_grouped_expr,
+      :"\n" => :parse_terminator,
+      eof: :parse_terminator,
+      child_start: :parse_child_segment,
+      dot: :parse_dot_notation,
+      descendants: :parse_descendant_segment,
+      filter: :parse_filter_selector,
+      null: :parse_null,
+    }.freeze
     LOWEST_PRECEDENCE = 0
     OPERATOR_PRECEDENCE = {
       ',' => 0,
@@ -144,27 +157,16 @@ module Janeway
     end
 
     def determine_parsing_function
-      if PARSE_METHOD_TYPES.include?(current.type)
-        :"parse_#{current.type}"
-      elsif current.type == :group_start # (
-        :parse_grouped_expr
-      elsif NEWLINE_OR_EOF_TYPES.include?(current.type)
-        :parse_terminator
-      elsif UNARY_OPERATOR_SET.include?(current.lexeme)
-        :parse_unary_operator
-      elsif current.type == :child_start # [
-        :parse_child_segment
-      elsif current.type == :dot # .
-        :parse_dot_notation
-      elsif current.type == :descendants # ..
-        :parse_descendant_segment
-      elsif current.type == :filter # ?
-        :parse_filter_selector
-      elsif current.type == :null # null
-        :parse_null
-      else
-        raise err("Don't know how to parse #{current}")
-      end
+      # Two type-driven tables plus a lexeme-driven check for unary operators.
+      # PARSE_METHOD_TYPES synthesizes the method name (`:parse_<type>`);
+      # PARSE_DISPATCH_BY_TYPE maps to a fixed method name.
+      return :"parse_#{current.type}" if PARSE_METHOD_TYPES.include?(current.type)
+
+      dispatch = PARSE_DISPATCH_BY_TYPE[current.type]
+      return dispatch if dispatch
+      return :parse_unary_operator if UNARY_OPERATOR_SET.include?(current.lexeme)
+
+      raise err("Don't know how to parse #{current}")
     end
 
     # @return [nil, Symbol]

--- a/lib/janeway/parser.rb
+++ b/lib/janeway/parser.rb
@@ -208,14 +208,16 @@ module Janeway
       end
 
       # '-' must be followed by a number token.
-      # Parse number and apply - sign to its literal value
+      # Consume the minus, then replace the following number token in the
+      # token stream with a copy that has the negated literal. Replacing —
+      # rather than mutating in place — keeps Token immutable.
       consume
-      parse_number
       unless current.literal.is_a?(Numeric)
         raise err("Minus operator \"-\" must be followed by number, got #{current.lexeme.inspect}")
       end
 
-      current.literal *= -1
+      original = current
+      @tokens[@next_p - 1] = Token.new(original.type, original.lexeme, -original.literal, original.location)
       current
     end
 

--- a/lib/janeway/query.rb
+++ b/lib/janeway/query.rb
@@ -137,5 +137,17 @@ module Janeway
       # Return the last selector
       nodes.last
     end
+
+    # Return a data-free split of this singular query into a "parent" Query
+    # plus the leaf selector — the parent addresses one level up from what
+    # `self` addresses. Used by Enumerator#insert to locate the container
+    # that a new value should be inserted into.
+    #
+    # @return [Array(Query, AST::Selector)] [parent_query, leaf_selector]
+    def parent_query
+      parent = dup
+      leaf = parent.pop
+      [parent, leaf]
+    end
   end
 end

--- a/lib/janeway/token.rb
+++ b/lib/janeway/token.rb
@@ -7,10 +7,7 @@ module Janeway
   class Token
     extend Forwardable
 
-    attr_reader :type, :lexeme, :location
-
-    # write-access so '-' operator can modify number value
-    attr_accessor :literal
+    attr_reader :type, :lexeme, :literal, :location
 
     def_delegators :@location, :line, :col, :length
 


### PR DESCRIPTION
**Description**

Two methods have grown into small classes' worth of responsibility, and two spots reach through object boundaries in ways that mask what they're doing.

**Items**

- **`Interpreter#query_to_interpreter_tree` (`interpreter.rb:69-107`)** — mixes: (a) constructing an interpreter per AST node, (b) appending a terminal for the interpretation type, (c) linking `@next` pointers, (d) rewriting child-segment branches in a subtle reverse pass. Each is its own concern. Suggested split: `build_interpreter_chain`, `append_terminal`, `rewire_child_segment_branches`. Or: extract the whole thing into an `InterpreterTreeBuilder` class and let `Interpreter` just call it. The docstring at the end of `interpreter.rb` already treats this as a separate topic.

  **Commit**: `eed3229` — split into `build_interpreters` / `append_terminal` / `link_next_pointers` / `rewire_child_segments`. Kept in `Interpreter` (didn't extract to a separate class — the four helpers make it readable enough).

- **`Parser#determine_parsing_function` (`parser.rb:137-160`)** — 20+ branch if/elsif ladder mixing type checks and lexeme checks. Convert to a dispatch `Hash` keyed on `current.type` with a small fallback for operator lexemes. Shorter, faster, and one place to look when adding a new token type.

  **Commit**: `922b68c` — reduced to 4 lines via `PARSE_DISPATCH_BY_TYPE` frozen hash + the existing `PARSE_METHOD_TYPES` set + unary-operator lexeme check. Also removed the now-unreachable `NEWLINE_OR_EOF_TYPES` constant.

- **`Interpreter#find_parent` (`enumerator.rb:136-150`)** — reaches into `Query` internals: dup, pop, then re-interpret. That entire flow is really "give me the parent query." Move to `Query#parent_query` (or an equivalent). Enumerator stops caring how it's implemented.

  **Commit**: `a7385bb` — `Query#parent_query` returns `[parent_query, leaf_selector]`; `find_parent` uses it and no longer knows about `dup`/`pop`.

- **Lexer inspects `@tokens.last&.type` (`lexer.rb:103, 484`)** to make lexing decisions. That's parser knowledge leaking into the lexer. Options: (a) keep a small `@state` flag the lexer updates itself; (b) accept the sloppier tokens and let the parser reject; (c) leave it and add a comment — this is the lowest-value item in the bucket.

  **Commit**: `315837b` — closer look showed the peeked types (`:dot`, `:child_start`) are lexer-emitted, so it's not really a lexer/parser separation issue. Reduced to naming: wrapped the peek in a `previous_token_type` helper. Both call sites now read `previous_token_type == :X`.

- **Parser mutates a Token in place: `current.literal *= -1` (`parser.rb:208`)** — that's why `Token#literal` needs `attr_accessor` instead of `attr_reader`. Change the parser to consume the number and wrap it in `AST::Number.new(-token.literal)`; make `Token#literal` a reader.

  **Commit**: `d92b010` — parser now REPLACES the number token in the stream with a copy that has the negated literal, rather than mutating the original Token. `Token#literal` becomes `attr_reader`. Also dropped a redundant `parse_number` call whose return was discarded.

